### PR TITLE
☎️ removed all diaas references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,10 +7,12 @@ about: Create a report to help us fixing breaking things
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior:
+Include steps to reproduce the behavior.
 
-1. Go to the url of a diaas-web-starter forked repository and clone it
-2. Install de dependencies and run the app
+Example:
+
+1. Create a new React App using `create-react-app`
+2. Install the `@dxc-technology\halstack-react` dependencies and run the app
 3. Click on '....'
 4. Scroll down to '....'
 5. See error

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Publish NEXT version to npm
       run: |
-        sed -i "s#\"version\": \"0.0.0\"#\"version\": \"$${{ steps.previoustag.outputs.tag }}-${GITHUB_SHA:0:7}\"#" ./lib/package.json
+        sed -i "s#\"version\": \"0.0.0\"#\"version\": \"${{ steps.previoustag.outputs.tag }}-${GITHUB_SHA:0:7}\"#" ./lib/package.json
         cd lib
         npm publish --tag next --access public
       env:

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -49,15 +49,9 @@ jobs:
     - name: Build docs
       run: cd docs && npm run build
       
-    - name: 'Get Latest tag'
-        id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@master"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
     - name: Publish NEXT version to npm
       run: |
-        sed -i "s#\"version\": \"0.0.0\"#\"version\": \"${{ steps.previoustag.outputs.tag }}-${GITHUB_SHA:0:7}\"#" ./lib/package.json
+        sed -i "s#\"version\": \"0.0.0\"#\"version\": \"0.0.0-${GITHUB_SHA:0:7}\"#" ./lib/package.json
         cd lib
         npm publish --tag next --access public
       env:

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -49,9 +49,15 @@ jobs:
     - name: Build docs
       run: cd docs && npm run build
       
+    - name: 'Get Latest tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@master"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
     - name: Publish NEXT version to npm
       run: |
-        sed -i "s#\"version\": \"0.0.0\"#\"version\": \"0.0.0-${GITHUB_SHA:0:7}\"#" ./lib/package.json
+        sed -i "s#\"version\": \"0.0.0\"#\"version\": \"$${{ steps.previoustag.outputs.tag }}-${GITHUB_SHA:0:7}\"#" ./lib/package.json
         cd lib
         npm publish --tag next --access public
       env:

--- a/docs/src/common/Header.jsx
+++ b/docs/src/common/Header.jsx
@@ -31,7 +31,7 @@ function App() {
             <a
               target="_blank"
               rel="noopener noreferrer"
-              href="https://github.dxc.com/DIaaS/diaas-react-cdk"
+              href="https://github.com/dxc-technology/halstack-react"
             >
               <HeaderLogo alt="GitHub logo" src={githubLogo}></HeaderLogo>
             </a>
@@ -63,7 +63,7 @@ function App() {
             <a
               target="_blank"
               rel="noopener noreferrer"
-              href="https://github.dxc.com/DIaaS/diaas-react-cdk"
+              href="https://github.com/dxc-technology/halstack-react"
             >
               <HeaderLogo alt="GitHub logo" src={githubLogoBlack}></HeaderLogo>
             </a>

--- a/docs/src/pages/overview/Overview.jsx
+++ b/docs/src/pages/overview/Overview.jsx
@@ -33,10 +33,10 @@ function Install() {
       <SyntaxHighlighter language="php" style={docco}>
         {`
   # with npm
-  npm install @diaas/dxc-react-cdk
+  npm install @dxc-technology/halstack-react
 
   # with yarn
-  yarn add @diaas/dxc-react-cdk
+  yarn add @dxc-technology/halstack-react
         `}
       </SyntaxHighlighter>
     </Section>
@@ -62,7 +62,7 @@ function UseComponents() {
       </p>
       <SyntaxHighlighter language="javascript" style={docco}>
         {`
-  import { DxcButton } from "@diaas/dxc-react-cdk";
+  import { DxcButton } from "@dxc-technology/halstack-react";
 
   const MyComponent = () => {
     const onClick = () => {
@@ -102,7 +102,7 @@ function CustomThemes() {
 
       <SyntaxHighlighter language="javascript" style={docco}>
         {`
-  import { DxcButton, ThemeContext } from "@diaas/dxc-react-cdk";
+  import { DxcButton, ThemeContext } from "@dxc-technology/halstack-react";
 
   const colors = {
     black: "#171515",
@@ -150,7 +150,7 @@ function Support() {
         </p>
         <DxcTag
           margin={{ top: "medium", bottom: "medium", right: "medium" }}
-          linkHref="https://github.dxc.com/DIaaS/diaas-react-cdk/issues"
+          linkHref="https://github.com/dxc-technology/halstack-react"
           iconSrc={githubLogo}
           label="GitHub Issues"
         ></DxcTag>

--- a/lib/src/accordion/readme.md
+++ b/lib/src/accordion/readme.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import { DxcAccordion } from "@diaas/dxc-react-cdk";
+import { DxcAccordion } from "@dxc-technology/halstack-react";
 
 <DxcAccordion onChange={handleOnChange} label="Test Accordion" />;
 ```
@@ -66,7 +66,7 @@ import { DxcAccordion } from "@diaas/dxc-react-cdk";
 ```js
 import React from "react";
 
-import { DxcAccordion } from "@diaas/dxc-react-cdk";
+import { DxcAccordion } from "@dxc-technology/halstack-react";
 
 function App() {
   const handleOnChange = event => {

--- a/lib/src/button/readme.md
+++ b/lib/src/button/readme.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import { DxcButton } from "@diaas/dxc-react-cdk";
+import { DxcButton } from "@dxc-technology/halstack-react";
 
 <DxcButton onClick={handleClick} label="Test Button" />;
 ```
@@ -66,7 +66,7 @@ import { DxcButton } from "@diaas/dxc-react-cdk";
 ```js
 import React from "react";
 
-import { DxcButton } from "@diaas/dxc-react-cdk";
+import { DxcButton } from "@dxc-technology/halstack-react";
 
 function App() {
   const handleOnClick = event => {

--- a/lib/src/checkbox/readme.md
+++ b/lib/src/checkbox/readme.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import { DxcCheckbox } from "@diaas/dxc-react-cdk";
+import { DxcCheckbox } from "@dxc-technology/halstack-react";
 
 <DxcCheckbox onChange={handleNewValue} label="Test Checkbox" checked={checked} />;
 ```
@@ -75,7 +75,7 @@ import { DxcCheckbox } from "@diaas/dxc-react-cdk";
 
 ```js
 import React from "react";
-import { DxcCheckbox } from "@diaas/dxc-react-cdk";
+import { DxcCheckbox } from "@dxc-technology/halstack-react";
 
 class App extends React.Component {
   state = {

--- a/lib/src/progress-bar/readme.md
+++ b/lib/src/progress-bar/readme.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import { DxcProgressBar } from "@diaas/dxc-react-cdk";
+import { DxcProgressBar } from "@dxc-technology/halstack-react";
 
 <DxcProgressBar onClick={handleClick} label="Test Button" />;
 ```
@@ -47,7 +47,7 @@ import { DxcProgressBar } from "@diaas/dxc-react-cdk";
 
 ```js
 import React from "react";
-import { DxcSpinner } from "@diaas/dxc-react-cdk";
+import { DxcSpinner } from "@dxc-technology/halstack-react";
 
 function App() {
   return (

--- a/lib/src/radio/readme.md
+++ b/lib/src/radio/readme.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import { DxcRadio } from "@diaas/dxc-react-cdk";
+import { DxcRadio } from "@dxc-technology/halstack-react";
 
 <DxcRadio onChange={handleNewValue} label="Test Radio" checked={checked} />;
 ```

--- a/lib/src/slider/readme.md
+++ b/lib/src/slider/readme.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import { Slider } from "@diaas/dxc-react-cdk";
+import { Slider } from "@dxc-technology/halstack-react";
 
 <DxcSlider min={0} max={100} step={1} value={value}  />;
 ```

--- a/lib/src/spinner/readme.md
+++ b/lib/src/spinner/readme.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import { DxcSpinner } from "@diaas/dxc-react-cdk";
+import { DxcSpinner } from "@dxc-technology/halstack-react";
 
 <Spinner theme="dark" label="Processing..." />;
 ```
@@ -48,7 +48,7 @@ import { DxcSpinner } from "@diaas/dxc-react-cdk";
 ```js
 import React from "react";
 
-import { DxcSpinner } from "@diaas/dxc-react-cdk";
+import { DxcSpinner } from "@dxc-technology/halstack-react";
 
 function App() {
   return (

--- a/lib/src/switch/readme.md
+++ b/lib/src/switch/readme.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import { DxcSwitch } from "@diaas/dxc-react-cdk";
+import { DxcSwitch } from "@dxc-technology/halstack-react";
 
 <DxcSwitch onChange={handleNewValue} label="Test Switch" checked={checked} />;
 ```
@@ -92,7 +92,7 @@ The API properties are the following:
 
 ```js
 import React from "react";
-import { DxcSwitch } from "@diaas/dxc-react-cdk";
+import { DxcSwitch } from "@dxc-technology/halstack-react";
 
 class App extends React.Component {
   state = {

--- a/lib/src/toggle/readme.md
+++ b/lib/src/toggle/readme.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import { DxcToggle } from "@diaas/dxc-react-cdk";
+import { DxcToggle } from "@dxc-technology/halstack-react";
 
 <DxcToggle onClick={handleClick} label="Test Button" />;
 ```
@@ -67,7 +67,7 @@ import { DxcToggle } from "@diaas/dxc-react-cdk";
 ## Examples
 
 ```js
-import { DxcToggle } from "@diaas/dxc-react-cdk";
+import { DxcToggle } from "@dxc-technology/halstack-react";
 <DxcToggle
   label="Disabled Ripple"
   disableRipple={true}

--- a/lib/src/upload/readme.md
+++ b/lib/src/upload/readme.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import { DxcUpload } from "@diaas/dxc-react-cdk";
+import { DxcUpload } from "@dxc-technology/halstack-react";
 ```
 
 ## Props
@@ -27,7 +27,7 @@ import { DxcUpload } from "@diaas/dxc-react-cdk";
 ```js
 import React from "react";
 
-import { DxcUpload } from "@diaas/dxc-react-cdk";
+import { DxcUpload } from "@dxc-technology/halstack-react";
 
 function App() {
   return <Upload callbackUpload={callbackFunc} />;


### PR DESCRIPTION
Removed all references to diaas, mostly links and library names in documentation files.

Also, for the `next` version generation on NPM, I am suggesting not naming it `0.0.0-XXX` by default, but instead, calculate what is the LATEST tag and use that as a prefix (e.g. current would be `0.0.1-XXX`). The proposed solution is based on [this solution](https://github.com/marketplace/actions/get-latest-tag) but I can't find a way of testing workflows without merging