### PR TITLE
[Patch] Select - avoid label displacement in focused option

### DIFF
--- a/lib/src/select/Select.jsx
+++ b/lib/src/select/Select.jsx
@@ -77,7 +77,7 @@ const useStyles = makeStyles(() => ({
         color: `${props.optionsFontColor || props.color}`,
       },
       "&:focus": {
-        border: `2px solid ${props.backgroundType === "dark" ? props.focusColorOnDark : props.focusColor}`,
+        outline: `${props.backgroundType === "dark" ? props.focusColorOnDark : props.focusColor} auto 2px`,
       },
       "&.MuiListItem-root.Mui-selected": {
         backgroundColor: `${


### PR DESCRIPTION
Now when you focus on an option the label does not move.