### PR TITLE
[Patch] Fix #373 Progress bar overlay z-index

### DIFF
--- a/lib/src/progress-bar/ProgressBar.jsx
+++ b/lib/src/progress-bar/ProgressBar.jsx
@@ -61,7 +61,7 @@ const BackgroundProgressBar = styled.div`
   bottom: ${(props) => (props.overlay === true ? "0" : "")};
   left: ${(props) => (props.overlay === true ? "0" : "")};
   right: ${(props) => (props.overlay === true ? "0" : "")};
-  z-index: ${(props) => (props.overlay ? 1000 : "")};
+  z-index: ${(props) => (props.overlay ? 1300 : "")};
 `;
 
 const DXCProgressBar = styled.div`


### PR DESCRIPTION
Changed z-index for progress bar with overlay. Z-index value is now the same as in spinner with overlay.