### PR TITLE
[Minor] Clearable for new-date, doc improvements & error icon container

### DIFF
--- a/app/src/pages/NewDate.jsx
+++ b/app/src/pages/NewDate.jsx
@@ -61,6 +61,7 @@ function App() {
           value={inputValue}
           onChange={onChange}
           margin={{ left: "medium", right: "medium" }}
+          clearable
         />
       </p>
       <p>
@@ -68,6 +69,7 @@ function App() {
           label="With label + placerholder"
           placeholder
           margin={{ left: "medium", right: "medium" }}
+          clearable
         />
       </p>
       <p>

--- a/docs/src/pages/components/cdk-components/new-date/api.jsx
+++ b/docs/src/pages/components/cdk-components/new-date/api.jsx
@@ -15,14 +15,15 @@ const NewDatePropsTable = () => {
           <code></code>
         </td>
         <td>
-          Value of the input element. If undefined, the component will be uncontrolled
-          and the value will be managed internally by the component.
+          Value of the input element. If undefined, the component will be
+          uncontrolled and the value will be managed internally by the
+          component.
         </td>
       </tr>
       <tr>
         <td>label: string</td>
         <td></td>
-        <td>Text to be placed above the input.</td>
+        <td>Text to be placed above the date.</td>
       </tr>
       <tr>
         <td>name: string</td>
@@ -32,13 +33,13 @@ const NewDatePropsTable = () => {
       <tr>
         <td>helperText: string</td>
         <td></td>
-        <td>Helper text to be placed above the input.</td>
+        <td>Helper text to be placed above the date.</td>
       </tr>
       <tr>
         <td>placeholder: boolean</td>
         <td>false</td>
         <td>
-          If true the date format will appear as placeholder in the field.
+          If true, the date format will appear as placeholder in the field.
         </td>
       </tr>
       <tr>
@@ -46,8 +47,17 @@ const NewDatePropsTable = () => {
         <td>'dd-MM-yyyy'</td>
         <td>
           The format in which the date value will be displayed. User must use
-          this format when editing the input or it will be considered as an
+          this format when editing the value or it will be considered as an
           invalid date.
+        </td>
+      </tr>
+      <tr>
+        <td>clearable: boolean</td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>
+          If true, the date will have an action to clear the entered value.
         </td>
       </tr>
       <tr>
@@ -63,7 +73,7 @@ const NewDatePropsTable = () => {
           <code>false</code>
         </td>
         <td>
-          If true, the input will be optional, showing <code>(Optional)</code>{" "}
+          If true, the date will be optional, showing <code>(Optional)</code>{" "}
           next to the label.
         </td>
       </tr>
@@ -71,10 +81,11 @@ const NewDatePropsTable = () => {
         <td>onChange: function</td>
         <td></td>
         <td>
-          This function will be called when the user types within the input. An
-          object including the current string value and the date value will be
-          passed to this function. An example of this object is: {"{ "}
-          <code>value: value, date: date </code>
+          This function will be called when the user types within the input
+          element of the component. An object including the current string value
+          and the date value will be passed to this function. An example of this
+          object is: {"{ "}
+          <code>value: value, date: date</code>
           {" }"}. If the string value is not a valid date, <code>date</code>{" "}
           will be null.
         </td>
@@ -83,10 +94,9 @@ const NewDatePropsTable = () => {
         <td>onBlur: function</td>
         <td></td>
         <td>
-          This function will be called when the input element of the component
-          loses the focus. An object including the string value, the error and
-          the date value will be passed to this function. An example of this
-          object is: {"{ "}
+          This function will be called when the input element loses the focus.
+          An object including the string value, the error and the date value
+          will be passed to this function. An example of this object is: {"{ "}
           <code>value: value, error: error, date: date</code>
           {" }"}. If the string value is a valid date, <code>error</code> will
           be null. Also, if the string value is not a valid date,{" "}
@@ -99,7 +109,7 @@ const NewDatePropsTable = () => {
         <td>
           If it is defined, the component will change its appearance, showing
           the error below the date component. If it is not defined, the error
-          messages will be managed internally by the component.
+          messages will be created and managed internally.
         </td>
       </tr>
       <tr>
@@ -129,7 +139,7 @@ const NewDatePropsTable = () => {
       <tr>
         <td>ref: object</td>
         <td></td>
-        <td>Reference to the date.</td>
+        <td>Reference to the component.</td>
       </tr>
     </DxcTable>
   );

--- a/docs/src/pages/components/cdk-components/new-date/examples/controlledDate.js
+++ b/docs/src/pages/components/cdk-components/new-date/examples/controlledDate.js
@@ -19,6 +19,7 @@ const code = `() => {
       onChange={onChange}
       onBlur={onBlur}
       margin="medium"
+      clearable
     />
   );
 }`;

--- a/docs/src/pages/components/cdk-components/new-date/examples/uncontrolledDate.js
+++ b/docs/src/pages/components/cdk-components/new-date/examples/uncontrolledDate.js
@@ -10,6 +10,7 @@ const code = `() => {
       label="Uncontrolled"
       onChange={onChange}
       margin="medium"
+      clearable
     />
   );
 }`;

--- a/docs/src/pages/components/cdk-components/new-input-text/api.jsx
+++ b/docs/src/pages/components/cdk-components/new-input-text/api.jsx
@@ -15,8 +15,9 @@ const newInputPropsTable = () => {
           <code></code>
         </td>
         <td>
-          Value of the input. If undefined, the component will be uncontrolled
-          and the value will be managed internally by the component.
+          Value of the input. If undefined, the component will be
+          uncontrolled and the value will be managed internally by the
+          component.
         </td>
       </tr>
       <tr>
@@ -58,8 +59,7 @@ const newInputPropsTable = () => {
           <code>false</code>
         </td>
         <td>
-          If true, the input will have an action to clear the value entered in
-          the input.
+          If true, the input will have an action to clear the entered value.
         </td>
       </tr>
       <tr>
@@ -114,17 +114,7 @@ const newInputPropsTable = () => {
         <td>
           If it is defined, the component will change its appearance, showing
           the error below the input component. If it is not defined, the error
-          messages will be created internally by the component.
-        </td>
-      </tr>
-      <tr>
-        <td>margin: string | object</td>
-        <td></td>
-        <td>
-          Size of the margin to be applied to the component ('xxsmall' |
-          'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-          can pass an object with 'top', 'bottom', 'left' and 'right' properties
-          in order to specify different margin sizes.
+          messages will be created and managed internally.
         </td>
       </tr>
       <tr>
@@ -174,6 +164,16 @@ const newInputPropsTable = () => {
         </td>
       </tr>
       <tr>
+        <td>margin: string | object</td>
+        <td></td>
+        <td>
+          Size of the margin to be applied to the component ('xxsmall' |
+          'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
+          can pass an object with 'top', 'bottom', 'left' and 'right' properties
+          in order to specify different margin sizes.
+        </td>
+      </tr>
+      <tr>
         <td>size: string | object</td>
         <td>
           <code>'medium'</code>
@@ -192,7 +192,7 @@ const newInputPropsTable = () => {
       <tr>
         <td>ref: object</td>
         <td></td>
-        <td>Reference to the input.</td>
+        <td>Reference to the component.</td>
       </tr>
     </DxcTable>
   );

--- a/docs/src/pages/components/cdk-components/new-input-text/examples/invalidInput.js
+++ b/docs/src/pages/components/cdk-components/new-input-text/examples/invalidInput.js
@@ -20,7 +20,6 @@ const code = `() => {
       onBlur={onBlur}
       margin="medium"
       error="Error message"
-      clearable
     />
   );
 }`;

--- a/docs/src/pages/components/cdk-components/number/api.jsx
+++ b/docs/src/pages/components/cdk-components/number/api.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { DxcTable } from "@dxc-technology/halstack-react";
 
-const numberPropsTable = () => {
+const NumberPropsTable = () => {
   return (
     <DxcTable>
       <tr>
@@ -13,8 +13,9 @@ const numberPropsTable = () => {
         <td>value: string</td>
         <td></td>
         <td>
-          Value of the number. If undefined, the component will be uncontrolled
-          and the value will be managed internally by the component.
+          Value of the input element. If undefined, the component will be
+          uncontrolled and the value will be managed internally by the
+          component.
         </td>
       </tr>
       <tr>
@@ -25,7 +26,7 @@ const numberPropsTable = () => {
       <tr>
         <td>name: string</td>
         <td></td>
-        <td>Name attribute of the number element.</td>
+        <td>Name attribute of the input element.</td>
       </tr>
       <tr>
         <td>helperText: string</td>
@@ -83,36 +84,36 @@ const numberPropsTable = () => {
         </td>
       </tr>
       <tr>
-        <td>error: string</td>
-        <td></td>
-        <td>
-          If it is defined, the component will change its appearance, showing
-          the error below the number component. If it is not defined, the error
-          messages will be created internally by the component.
-        </td>
-      </tr>
-      <tr>
         <td>onChange: function</td>
         <td></td>
         <td>
-          This function will be called when the user types within the number.
-          The new value will be passed as a parameter.
+          This function will be called when the user types within the input
+          element of the component. The new value will be passed as a parameter.
         </td>
       </tr>
       <tr>
         <td>onBlur: function</td>
         <td></td>
         <td>
-          This function will be called when the number loses the focus. An
-          object including the value and the error (if the value entered is not
-          valid) will be passed to this function. An example of this object is:{" "}
-          {"{ "}
+          This function will be called when the input element loses the focus.
+          An object including the value and the error (if the value entered is
+          not valid) will be passed to this function. An example of this object
+          is: {"{ "}
           <code>value: value, error: error</code>
           {" }"}. If there is no error, error will be null.
         </td>
       </tr>
       <tr>
-        <td>margin: function</td>
+        <td>error: string</td>
+        <td></td>
+        <td>
+          If it is defined, the component will change its appearance, showing
+          the error below the number component. If it is not defined, the error
+          messages will be created and managed internally.
+        </td>
+      </tr>
+      <tr>
+        <td>margin: string | object</td>
         <td></td>
         <td>
           Size of the margin to be applied to the component ('xxsmall' |
@@ -140,10 +141,10 @@ const numberPropsTable = () => {
       <tr>
         <td>ref: object</td>
         <td></td>
-        <td>Reference to the number.</td>
+        <td>Reference to the component.</td>
       </tr>
     </DxcTable>
   );
 };
 
-export default numberPropsTable;
+export default NumberPropsTable;

--- a/docs/src/pages/components/cdk-components/password/api.jsx
+++ b/docs/src/pages/components/cdk-components/password/api.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { DxcTable } from "@dxc-technology/halstack-react";
 
-const passwordPropsTable = () => {
+const PasswordPropsTable = () => {
   return (
     <DxcTable>
       <tr>
@@ -13,7 +13,7 @@ const passwordPropsTable = () => {
         <td>value: string</td>
         <td></td>
         <td>
-          Value of the password. If undefined, the component will be
+          Value of the input element. If undefined, the component will be
           uncontrolled and the value will be managed internally by the
           component.
         </td>
@@ -26,7 +26,7 @@ const passwordPropsTable = () => {
       <tr>
         <td>name: string</td>
         <td></td>
-        <td>Name attribute of the password element.</td>
+        <td>Name attribute of the input element.</td>
       </tr>
       <tr>
         <td>helperText: string</td>
@@ -34,62 +34,51 @@ const passwordPropsTable = () => {
         <td>Helper text to be placed above the password.</td>
       </tr>
       <tr>
-        <td>error: string</td>
-        <td></td>
-        <td>
-          If it is defined, the component will change its appearance, showing
-          the error below the password component. If it is not defined, the
-          error messages will be created internally by the component.
-        </td>
-      </tr>
-      <tr>
         <td>clearable: boolean</td>
         <td>
           <code>false</code>
         </td>
         <td>
-          If true, the input will have an action to clear the value entered in
-          the password.
+          If true, the password will have an action to clear the entered value.
         </td>
       </tr>
       <tr>
         <td>onChange: function</td>
         <td></td>
         <td>
-          This function will be called when the user types within the password.
-          The new value will be passed as a parameter.
+          This function will be called when the user types within the input
+          element of the component. The new value will be passed as a parameter.
         </td>
       </tr>
       <tr>
         <td>onBlur: function</td>
         <td></td>
         <td>
-          This function will be called when the password loses the focus. An
-          object including the value and the error (if the value entered is not
-          valid) will be passed to this function. An example of this object is:{" "}
-          {"{ "}
+          This function will be called when the input element loses the focus.
+          An object including the value and the error (if the value entered is
+          not valid) will be passed to this function. An example of this object
+          is: {"{ "}
           <code>value: value, error: error</code>
           {" }"}. If there is no error, error will be null.
         </td>
       </tr>
       <tr>
-        <td>margin: function</td>
+        <td>error: string</td>
         <td></td>
         <td>
-          Size of the margin to be applied to the component ('xxsmall' |
-          'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-          can pass an object with 'top', 'bottom', 'left' and 'right' properties
-          in order to specify different margin sizes.
+          If it is defined, the component will change its appearance, showing
+          the error below the password component. If it is not defined, the
+          error messages will be created and managed internally.
         </td>
       </tr>
       <tr>
-        <td>pattern: string </td>
+        <td>pattern: string</td>
         <td></td>
         <td>
           Regular expression that defines the valid format allowed by the
-          password. This will be checked when the password loses the focus. If
-          the value entered does not match the pattern, the onBlur function will
-          be called with the value entered and the error informing that the
+          password. This will be checked when the input element loses the focus.
+          If the value entered does not match the pattern, the onBlur function
+          will be called with the value entered and the error informing that the
           value does not match the pattern as parameters. If the pattern is
           accomplished, the error parameter will be null.
         </td>
@@ -106,6 +95,16 @@ const passwordPropsTable = () => {
           called with the value entered and the error informing that the value
           does not comply the length as parameters. If the length is
           accomplished, the error parameter will be null.
+        </td>
+      </tr>
+      <tr>
+        <td>margin: string | object</td>
+        <td></td>
+        <td>
+          Size of the margin to be applied to the component ('xxsmall' |
+          'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
+          can pass an object with 'top', 'bottom', 'left' and 'right' properties
+          in order to specify different margin sizes.
         </td>
       </tr>
       <tr>
@@ -127,10 +126,10 @@ const passwordPropsTable = () => {
       <tr>
         <td>ref: object</td>
         <td></td>
-        <td>Reference to the password.</td>
+        <td>Reference to the component.</td>
       </tr>
     </DxcTable>
   );
 };
 
-export default passwordPropsTable;
+export default PasswordPropsTable;

--- a/lib/src/new-date/NewDate.jsx
+++ b/lib/src/new-date/NewDate.jsx
@@ -20,6 +20,7 @@ const DxcNewDate = React.forwardRef(
       format = "dd-MM-yyyy",
       helperText = "",
       placeholder = false,
+      clearable = false,
       disabled = false,
       optional = false,
       onChange,
@@ -256,6 +257,7 @@ const DxcNewDate = React.forwardRef(
                 helperText={helperText}
                 placeholder={placeholder ? format.toUpperCase() : null}
                 action={calendarAction}
+                clearable={clearable}
                 disabled={disabled}
                 optional={optional}
                 onChange={handleIOnChange}
@@ -319,6 +321,7 @@ DxcNewDate.propTypes = {
   format: PropTypes.string,
   helperText: PropTypes.string,
   placeholder: PropTypes.bool,
+  clearable: PropTypes.bool,
   disabled: PropTypes.bool,
   optional: PropTypes.bool,
   onChange: PropTypes.func,

--- a/lib/src/new-input-text/NewInputText.jsx
+++ b/lib/src/new-input-text/NewInputText.jsx
@@ -106,7 +106,7 @@ const DxcNewInputText = React.forwardRef(
     };
 
     const hasInputSuggestions = () => typeof suggestions === "function" || (suggestions && suggestions.length > 0);
-    
+
     const openSuggestions = () => {
       hasInputSuggestions() && changeIsOpen(true);
     };
@@ -846,6 +846,7 @@ const ErrorIcon = styled.span`
   display: flex;
   flex-wrap: wrap;
   align-content: center;
+  padding: 3px;
   height: 18px;
   width: 18px;
   margin-left: calc(1rem * 0.25);

--- a/lib/test/NewDate.test.js
+++ b/lib/test/NewDate.test.js
@@ -5,16 +5,19 @@ import userEvent from "@testing-library/user-event";
 import DxcNewDate from "../src/new-date/NewDate";
 
 describe("NewDate component tests", () => {
-  test("Renders with correct label, helper text, optional and placeholder", () => {
-    const { getByText, getByRole } = render(
-      <DxcNewDate label="Example label" helperText="Example of helper text" placeholder optional />
+  test("Renders with correct label, helper text, optional, placeholder and clearable action", () => {
+    const { getByText, getByRole, getAllByRole } = render(
+      <DxcNewDate label="Example label" helperText="Example of helper text" placeholder optional clearable />
     );
     const input = getByRole("textbox");
-
     expect(getByText("Example label")).toBeTruthy();
     expect(getByText("Example of helper text")).toBeTruthy();
     expect(getByText("(Optional)")).toBeTruthy();
     expect(input.getAttribute("placeholder")).toBe("DD-MM-YYYY");
+    userEvent.type(input, "10/90/2010");
+    const closeAction = getAllByRole("button")[0];
+    userEvent.click(closeAction);
+    expect(input.value).toBe("");
   });
 
   test("Renders with personalized error", () => {


### PR DESCRIPTION
Summary:

- Added `clearable` prop for the new-date component. This involves new tests, docs updated and added examples in app.
- Compared and unified number, password, new-input, new-date and new-textarea documentations.
- Fixed an issue related to Error's icon container in the new inputs.