### PR TITLE
[Patch] Change length error message.

### DIFF
--- a/lib/src/new-input-text/NewInputText.jsx
+++ b/lib/src/new-input-text/NewInputText.jsx
@@ -24,7 +24,7 @@ const makeCancelable = (promise) => {
   };
 };
 
-const getLengthErrorMessage = (length) => `Min length ${length.min}, Max length ${length.max}.`;
+const getLengthErrorMessage = (length) => `Min length ${length.min}, max length ${length.max}.`;
 
 const patternMatch = (pattern, value) => new RegExp(pattern).test(value);
 

--- a/lib/src/new-textarea/NewTextarea.jsx
+++ b/lib/src/new-textarea/NewTextarea.jsx
@@ -8,7 +8,7 @@ import { v4 as uuidv4 } from "uuid";
 import BackgroundColorContext from "../BackgroundColorContext.js";
 import { useLayoutEffect } from "react";
 
-const getLengthErrorMessage = (length) => `Min length ${length.min}, Max length ${length.max}.`;
+const getLengthErrorMessage = (length) => `Min length ${length.min}, max length ${length.max}.`;
 
 const patternMatch = (pattern, value) => new RegExp(pattern).test(value);
 

--- a/lib/test/NewInputText.test.js
+++ b/lib/test/NewInputText.test.js
@@ -95,7 +95,7 @@ describe("NewInputText component tests", () => {
     const input = getByRole("textbox");
     userEvent.type(input, "test");
     fireEvent.blur(input);
-    expect(getByText("Min length 5, Max length 10.")).toBeTruthy();
+    expect(getByText("Min length 5, max length 10.")).toBeTruthy();
     userEvent.type(input, "test ");
     fireEvent.blur(input);
     expect(queryByText(/Min length /)).toBeFalsy();
@@ -118,7 +118,7 @@ describe("NewInputText component tests", () => {
     const input = getByRole("textbox");
     userEvent.type(input, "test");
     fireEvent.blur(input);
-    expect(getByText("Min length 5, Max length 10.")).toBeTruthy();
+    expect(getByText("Min length 5, max length 10.")).toBeTruthy();
     userEvent.type(input, "test ");
     fireEvent.blur(input);
     expect(getByText("Please match the format requested.")).toBeTruthy();
@@ -155,7 +155,7 @@ describe("NewInputText component tests", () => {
     });
     const onBlur = jest.fn(({ value, error }) => {
       expect(value).toBe("t");
-      expect(error).toBe("Min length 5, Max length 10.");
+      expect(error).toBe("Min length 5, max length 10.");
     });
     const { getByRole } = render(
       <DxcNewInputText
@@ -178,7 +178,7 @@ describe("NewInputText component tests", () => {
     });
     const onBlur = jest.fn(({ value, error }) => {
       expect(value).toBe("t");
-      expect(error).toBe("Min length 5, Max length 10.");
+      expect(error).toBe("Min length 5, max length 10.");
     });
     const { getByRole } = render(
       <DxcNewInputText
@@ -558,7 +558,7 @@ describe("NewInputText component synchronous autosuggest tests", () => {
     fireEvent.mouseUp(option);
     expect(onChange).toHaveBeenCalledWith("Chad");
     fireEvent.blur(input);
-    expect(queryByText("Min length 5, Max length 10.")).toBeTruthy();
+    expect(queryByText("Min length 5, max length 10.")).toBeTruthy();
   });
   test("Autosuggest keys: arrow down key opens autosuggest, active first option is selected with Enter and closes the autosuggest", async () => {
     Element.prototype.scrollTo = () => {};

--- a/lib/test/NewTextarea.test.js
+++ b/lib/test/NewTextarea.test.js
@@ -70,7 +70,7 @@ describe("NewTextarea component tests", () => {
     const textarea = getByLabelText("Example label");
     fireEvent.change(textarea, { target: { value: "test" } });
     fireEvent.blur(textarea);
-    expect(getByText("Min length 5, Max length 10.")).toBeTruthy();
+    expect(getByText("Min length 5, max length 10.")).toBeTruthy();
     fireEvent.change(textarea, { target: { value: "test " } });
     fireEvent.blur(textarea);
     expect(queryByText(/Min length /)).toBeFalsy();
@@ -92,7 +92,7 @@ describe("NewTextarea component tests", () => {
     const textarea = getByLabelText("Example label");
     fireEvent.change(textarea, { target: { value: "test" } });
     fireEvent.blur(textarea);
-    expect(getByText("Min length 5, Max length 10.")).toBeTruthy();
+    expect(getByText("Min length 5, max length 10.")).toBeTruthy();
     fireEvent.change(textarea, { target: { value: "test " } });
     fireEvent.blur(textarea);
     expect(getByText("Please match the format requested.")).toBeTruthy();
@@ -128,7 +128,7 @@ describe("NewTextarea component tests", () => {
     });
     const onBlur = jest.fn(({ value, error }) => {
       expect(value).toBe("Example value");
-      expect(error).toBe("Min length 5, Max length 10.");
+      expect(error).toBe("Min length 5, max length 10.");
     });
     const { getByLabelText } = render(
       <DxcNewTextarea
@@ -150,7 +150,7 @@ describe("NewTextarea component tests", () => {
     });
     const onBlur = jest.fn(({ value, error }) => {
       expect(value).toBe("Example value");
-      expect(error).toBe("Min length 5, Max length 10.");
+      expect(error).toBe("Min length 5, max length 10.");
     });
     const { getByLabelText } = render(
       <DxcNewTextarea


### PR DESCRIPTION
- Small change in length error message. "Min length ${length.min}, Max length ${length.max}." changed to "Min length ${length.min}, max length ${length.max}."