### PR TITLE
[Patch] Fix #402 Dropdown additional space

### DIFF
--- a/app/src/pages/Dropdown.jsx
+++ b/app/src/pages/Dropdown.jsx
@@ -92,12 +92,23 @@ const twitterSVG = () => {
     </svg>
   );
 };
+const more_hor = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="24px"
+    viewBox="0 0 24 24"
+    width="24px"
+    fill="currentColor"
+  >
+    <path d="M0 0h24v24H0V0z" fill="none" />
+    <path d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+  </svg>
+);
 
 function App() {
   const selectOption = () => {
     console.log("selected");
   };
-
   const optionsWithoutIcon = [
     {
       value: 1,
@@ -276,6 +287,27 @@ function App() {
           onSelectOption={selectOption}
           label="Basic dropdown"
           margin="medium"
+        ></DxcDropdown>
+      </div>
+      <h4>Icon without caret and label</h4>
+      <div>
+        <DxcDropdown
+          options={optionsWithoutIcon}
+          onSelectOption={(option) => console.log(option)}
+          caretHidden={true}
+          icon={more_hor}
+          margin="small"
+        ></DxcDropdown>
+      </div>
+      <h4>Icon & Label</h4>
+      <div>
+        <DxcDropdown
+          options={optionsWithoutIcon}
+          onSelectOption={(option) => console.log(option)}
+          caretHidden={true}
+          label="Icon & Label"
+          icon={more_hor}
+          margin="small"
         ></DxcDropdown>
       </div>
       <div>

--- a/lib/src/dropdown/Dropdown.jsx
+++ b/lib/src/dropdown/Dropdown.jsx
@@ -111,13 +111,8 @@ const DxcDropdown = ({
                 {label}
               </DropdownTriggerLabel>
             </DropdownTriggerContainer>
-            <CaretIconContainer disabled={disabled}>
-              {caretHidden !== true &&
-                (anchorEl === null ? (
-                  <DownArrowIcon caretHidden={caretHidden} margin={margin} />
-                ) : (
-                  <UpArrowIcon caretHidden={caretHidden} margin={margin} />
-                ))}
+            <CaretIconContainer caretHidden={caretHidden} disabled={disabled}>
+              {!caretHidden && (anchorEl === null ? <DownArrowIcon /> : <UpArrowIcon />)}
             </CaretIconContainer>
           </DropdownTrigger>
           <DXCMenu
@@ -386,15 +381,13 @@ const ListIconContainer = styled.div`
 `;
 
 const CaretIconContainer = styled.div`
-  display: ${(props) => (props.caretHidden === true ? "none" : "inline-flex")};
-  width: ${(props) => props.theme.caretIconSize};
-  height: ${(props) => props.theme.caretIconSize};
+  display: ${(props) => (props.caretHidden ? "none" : "inline-flex")};
   margin-left: ${(props) => props.theme.caretIconSpacing};
   color: ${(props) => (props.disabled ? props.theme.disabledColor : props.theme.caretIconColor)};
 
   svg {
-    height: 100%;
-    width: 100%;
+    width: ${(props) => props.theme.caretIconSize};
+    height: ${(props) => props.theme.caretIconSize};
   }
 `;
 


### PR DESCRIPTION
Fixed issue #402 in Dropdown. Removed the whitespace when caret is hidden (`caretHidden = {true}`).