### PR TITLE
[Major] Rename DxcUpload to V3DxcUpload.

### DIFF
--- a/app/src/pages/Upload.jsx
+++ b/app/src/pages/Upload.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DxcUpload } from "@dxc-technology/halstack-react";
+import { V3DxcUpload } from "@dxc-technology/halstack-react";
 
 function App() {
   async function callbackFunc() {
@@ -7,7 +7,7 @@ function App() {
     return result;
   }
 
-  return <DxcUpload margin="small" callbackUpload={callbackFunc} />;
+  return <V3DxcUpload margin="small" callbackUpload={callbackFunc} />;
 }
 
 export default App;

--- a/docs/src/pages/components/cdk-components/file-input/FileInput.jsx
+++ b/docs/src/pages/components/cdk-components/file-input/FileInput.jsx
@@ -17,10 +17,7 @@ import disabled from "./examples/disabled";
 function FileInput() {
   return (
     <ComponentDoc>
-      <ComponentHeader
-        title="File Input"
-        status="experimental"
-      ></ComponentHeader>
+      <ComponentHeader title="File Input" status="ready"></ComponentHeader>
       <DxcTabsForSections
         stickAtPx={64}
         tabsMode="underlined"

--- a/docs/src/pages/components/cdk-components/upload/Upload.jsx
+++ b/docs/src/pages/components/cdk-components/upload/Upload.jsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { DxcTabsForSections, DxcHeading } from "@dxc-technology/halstack-react";
+import {
+  DxcTabsForSections,
+  DxcHeading,
+  DxcAlert,
+  DxcLink,
+} from "@dxc-technology/halstack-react";
 import ComponentDoc from "../../common/ComponentDoc";
 import Example from "../../common/Example";
 import ComponentHeader from "../../common/ComponentHeader";
@@ -10,7 +15,17 @@ import upload from "./examples/upload";
 function Upload() {
   return (
     <ComponentDoc>
-      <ComponentHeader title="Upload" status="ready"></ComponentHeader>
+      <ComponentHeader title="Upload" status="deprecated"></ComponentHeader>
+      <DxcAlert type="warning" margin={{ bottom: "small" }} size="fillParent">
+        The component status has been changed to deprecated. Use the new{" "}
+        <DxcLink
+          href="#/components/fileInput"
+          underlined={false}
+          inheritedColor={true}
+          text="File Input"
+        ></DxcLink>{" "}
+        component instead.
+      </DxcAlert>
       <DxcTabsForSections
         stickAtPx={64}
         tabsMode="underlined"

--- a/docs/src/pages/components/cdk-components/upload/examples/upload.js
+++ b/docs/src/pages/components/cdk-components/upload/examples/upload.js
@@ -1,4 +1,4 @@
-import { DxcUpload } from "@dxc-technology/halstack-react";
+import { V3DxcUpload } from "@dxc-technology/halstack-react";
 
 const code = `() => {
   async function callbackFunc(file) {
@@ -6,11 +6,11 @@ const code = `() => {
     return new Promise(resolve => setTimeout(resolve, 1000));
   }
 
-  return <DxcUpload margin="small" callbackUpload={callbackFunc} />;
+  return <V3DxcUpload margin="small" callbackUpload={callbackFunc} />;
 }`;
 
 const scope = {
-  DxcUpload
+  V3DxcUpload,
 };
 
 export default { code, scope };

--- a/docs/src/pages/themeBuilder/components/previews/Upload.jsx
+++ b/docs/src/pages/themeBuilder/components/previews/Upload.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { DxcUpload } from "@dxc-technology/halstack-react";
+import { V3DxcUpload } from "@dxc-technology/halstack-react";
 
 const Upload = () => {
   const callbackFunc = async (file) => {
@@ -12,7 +12,7 @@ const Upload = () => {
     <UploadContainer>
       <Title>Default</Title>
       <UploadPreview>
-        <DxcUpload margin={{ top: "small" }} callbackUpload={callbackFunc} />
+        <V3DxcUpload margin={{ top: "small" }} callbackUpload={callbackFunc} />
       </UploadPreview>
     </UploadContainer>
   );

--- a/lib/src/main.js
+++ b/lib/src/main.js
@@ -17,7 +17,7 @@ import DxcTabs from "./tabs/Tabs";
 import DxcTabsForSections from "./tabs-for-sections/TabsForSections";
 import DxcProgressBar from "./progress-bar/ProgressBar";
 import DxcSpinner from "./spinner/Spinner";
-import DxcUpload from "./upload/Upload";
+import V3DxcUpload from "./upload/Upload";
 import DxcTable from "./table/Table";
 import DxcBox from "./box/Box";
 import DxcTag from "./tag/Tag";
@@ -67,7 +67,7 @@ export {
   DxcProgressBar,
   DxcAccordion,
   DxcSpinner,
-  DxcUpload,
+  V3DxcUpload,
   DxcBox,
   DxcTag,
   DxcPaginator,

--- a/lib/src/upload/Upload.jsx
+++ b/lib/src/upload/Upload.jsx
@@ -8,7 +8,7 @@ import FilesToUpload from "./files-upload/FilesToUpload";
 import Transactions from "./transactions/Transactions";
 import { spaces } from "../common/variables.js";
 
-const DxcUpload = ({ callbackUpload, margin, tabIndex = 0 }) => {
+const V3DxcUpload = ({ callbackUpload, margin, tabIndex = 0 }) => {
   const [files, setFiles] = useState([]);
 
   const getFilesToUpload = () => {
@@ -130,7 +130,7 @@ const DxcUpload = ({ callbackUpload, margin, tabIndex = 0 }) => {
   );
 };
 
-DxcUpload.propTypes = {
+V3DxcUpload.propTypes = {
   callbackUpload: PropTypes.func,
   margin: PropTypes.oneOfType([
     PropTypes.shape({
@@ -162,4 +162,4 @@ const DXCUpload = styled.div`
     props.margin && typeof props.margin === "object" && props.margin.left ? spaces[props.margin.left] : ""};
 `;
 
-export default DxcUpload;
+export default V3DxcUpload;

--- a/lib/src/upload/readme.md
+++ b/lib/src/upload/readme.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```js
-import { DxcUpload } from "@dxc-technology/halstack-react";
+import { V3DxcUpload } from "@dxc-technology/halstack-react";
 ```
 
 ## Props
@@ -27,7 +27,7 @@ import { DxcUpload } from "@dxc-technology/halstack-react";
 ```js
 import React from "react";
 
-import { DxcUpload } from "@dxc-technology/halstack-react";
+import { V3DxcUpload } from "@dxc-technology/halstack-react";
 
 function App() {
   return <Upload callbackUpload={callbackFunc} />;

--- a/lib/test/Upload.test.js
+++ b/lib/test/Upload.test.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { render, fireEvent, act, createEvent } from "@testing-library/react";
-import DxcUpload from "../src/upload/Upload";
+import V3DxcUpload from "../src/upload/Upload";
 
 describe("Upload component tests", () => {
   test("Upload renders with correct text", () => {
-    const { getByText } = render(<DxcUpload margin="small"></DxcUpload>);
+    const { getByText } = render(<V3DxcUpload margin="small"></V3DxcUpload>);
     expect(getByText("There are no files to upload")).toBeTruthy();
     expect(getByText("Drag and drop your files here or choose one from your computer")).toBeTruthy();
     expect(getByText("CHOOSE FILES")).toBeTruthy();
@@ -12,7 +12,7 @@ describe("Upload component tests", () => {
 
   test("Upload shows file information", () => {
     const myfunction = jest.fn();
-    const { getByText } = render(<DxcUpload margin="small"></DxcUpload>);
+    const { getByText } = render(<V3DxcUpload margin="small"></V3DxcUpload>);
 
     const dropZone = getByText("There are no files to upload");
     const dropEvent = createEvent.drop(dropZone);
@@ -34,9 +34,9 @@ describe("Upload component tests", () => {
   });
 
   test("Calls correct function callbackUpload", () => {
-    const onCallbackUpload = jest.fn(() => new Promise(resolve => setTimeout(resolve, 1000)));
+    const onCallbackUpload = jest.fn(() => new Promise((resolve) => setTimeout(resolve, 1000)));
     const myfunction = jest.fn();
-    const { getByText } = render(<DxcUpload margin="small" callbackUpload={onCallbackUpload}></DxcUpload>);
+    const { getByText } = render(<V3DxcUpload margin="small" callbackUpload={onCallbackUpload}></V3DxcUpload>);
 
     const dropZone = getByText("There are no files to upload");
     const dropEvent = createEvent.drop(dropZone);


### PR DESCRIPTION
- Renamed `DxcUpload` export to `V3DxcUpload`.
- Marked Upload as `Deprecated` using the chip and using a warning alert.
- Marked File Input as `Ready`.