### PR TITLE
[Patch] Text input in slider.

### DIFF
--- a/lib/src/slider/Slider.jsx
+++ b/lib/src/slider/Slider.jsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useContext } from "react";
 import Slider from "@material-ui/lab/Slider";
 import styled, { ThemeProvider } from "styled-components";
 import PropTypes from "prop-types";
-import V3DxcInputText from "../input-text/InputText";
+import DxcTextInput from "../text-input/TextInput";
 import { spaces } from "../common/variables.js";
 import { getMargin } from "../common/utils.js";
 import useTheme from "../useTheme.js";
@@ -50,12 +50,22 @@ const DxcSlider = ({
       onChange(newValue);
     }
   };
+
   const handlerInputChange = (event) => {
+    const intValue = parseInt(event.value, 10);
     if (value == null) {
-      setInnerValue(event > maxValue ? maxValue : event);
+      if (!Number.isNaN(intValue)) {
+        setInnerValue(intValue > maxValue ? maxValue : intValue);
+      } else {
+        setInnerValue("");
+      }
     }
     if (typeof onChange === "function") {
-      onChange(event > maxValue ? maxValue : event);
+      if (!Number.isNaN(intValue)) {
+        onChange(intValue > maxValue ? maxValue : intValue);
+      } else {
+        onChange("");
+      }
     }
   };
 
@@ -87,12 +97,12 @@ const DxcSlider = ({
           )}
           {showInput && (
             <StyledTextInput>
-              <V3DxcInputText
+              <DxcTextInput
                 name={name}
                 value={(value != null && value >= 0 && value) || innerValue}
                 disabled={disabled}
                 onChange={handlerInputChange}
-                size="small"
+                size="fillParent"
               />
             </StyledTextInput>
           )}
@@ -314,6 +324,7 @@ const StyledTextInput = styled.div`
   label + .MuiInput-formControl {
     margin-top: 2px;
   }
+  max-width: 70px;
 `;
 
 DxcSlider.propTypes = {

--- a/lib/test/Slider.test.js
+++ b/lib/test/Slider.test.js
@@ -4,7 +4,7 @@ import DxcSlider from "../src/slider/Slider";
 
 describe("Slider component tests", () => {
   test("Slider renders with correct text", () => {
-    const { getByText } = render(<DxcSlider minValue={0} maxValue={100} showLimitsValues></DxcSlider>);
+    const { getByText } = render(<DxcSlider minValue={0} maxValue={100} showLimitsValues />);
     expect(getByText("0")).toBeTruthy();
     expect(getByText("100")).toBeTruthy();
   });
@@ -12,37 +12,29 @@ describe("Slider component tests", () => {
   test("Calls correct function onChange in controlled slider", () => {
     const onChange = jest.fn();
     const { getByRole } = render(
-      <DxcSlider minValue={0} maxValue={100} onChange={onChange} showLimitsValues value={13} showInput></DxcSlider>
+      <DxcSlider minValue={0} maxValue={100} onChange={onChange} showLimitsValues value={13} showInput />
     );
     act(() => {
       fireEvent.change(getByRole("textbox"), { target: { value: 25 } });
     });
-    expect(onChange).toHaveBeenCalledWith("25");
+    expect(onChange).toHaveBeenCalledWith(25);
   });
 
   test("Calls correct function onChange in uncontrolled slider", () => {
     const onChange = jest.fn();
     const { getByRole } = render(
-      <DxcSlider minValue={0} maxValue={100} onChange={onChange} showLimitsValues showInput></DxcSlider>
+      <DxcSlider minValue={0} maxValue={100} onChange={onChange} showLimitsValues showInput />
     );
     act(() => {
       fireEvent.change(getByRole("textbox"), { target: { value: 25 } });
     });
-    expect(onChange).toHaveBeenCalledWith("25");
+    expect(onChange).toHaveBeenCalledWith(25);
   });
 
   test("Disabled slider have disabled input", () => {
     const onChange = jest.fn();
     const { getByRole } = render(
-      <DxcSlider
-        minValue={0}
-        maxValue={100}
-        onChange={onChange}
-        showLimitsValues
-        disabled
-        showInput
-        value={13}
-      ></DxcSlider>
+      <DxcSlider minValue={0} maxValue={100} onChange={onChange} showLimitsValues disabled showInput value={13} />
     );
     act(() => {
       fireEvent.change(getByRole("textbox"), { target: { value: 25 } });
@@ -54,7 +46,7 @@ describe("Slider component tests", () => {
   test("Calls correct function onDragEnd", () => {
     const onDragEnd = jest.fn();
     const { getByRole } = render(
-      <DxcSlider minValue={0} maxValue={100} showLimitsValues showInput onDragEnd={onDragEnd} value={25}></DxcSlider>
+      <DxcSlider minValue={0} maxValue={100} showLimitsValues showInput onDragEnd={onDragEnd} value={25} />
     );
     act(() => {
       fireEvent.mouseDown(getByRole("slider"));
@@ -64,7 +56,7 @@ describe("Slider component tests", () => {
   });
 
   test("Calls correct function labelFormatCallback", () => {
-    const labelFormatCallback = jest.fn(x => `${x}$`);
+    const labelFormatCallback = jest.fn((x) => `${x}$`);
     const { getByText } = render(
       <DxcSlider
         minValue={0}
@@ -73,7 +65,7 @@ describe("Slider component tests", () => {
         showInput
         value={25}
         labelFormatCallback={labelFormatCallback}
-      ></DxcSlider>
+      />
     );
     expect(getByText("0$")).toBeTruthy();
     expect(getByText("100$")).toBeTruthy();


### PR DESCRIPTION
- Replaced `V3 Input Text` by `Text Input` in slider.
- Added check to only write numbers in slider's input.
- Changed text input size to `fillParent` and added `max-width` to its container.
- Changes in slider test.