### PR TITLE
[Minor] Rename V3DxcInputText to DxcInputText.

### DIFF
--- a/app/src/pages/InputText.jsx
+++ b/app/src/pages/InputText.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { V3DxcInputText, ThemeProvider } from "@dxc-technology/halstack-react";
+import { DxcInputText, ThemeProvider } from "@dxc-technology/halstack-react";
 import icon from "../images/home.svg";
 
 const colors = {
@@ -138,7 +138,7 @@ function App() {
     <div>
       <div className="test-case" id="prefix-suffix-icon-input">
         <h4>With prefix and suffix icons</h4>
-        <V3DxcInputText
+        <DxcInputText
           label="Input text label"
           suffixIcon={iconSVG}
           prefixIcon={iconSVG}
@@ -149,7 +149,7 @@ function App() {
 
       <div className="test-case" id="prefix-icon-input">
         <h4>With prefix icon</h4>
-        <V3DxcInputText
+        <DxcInputText
           label="Input text label"
           prefixIcon={
             <svg
@@ -176,7 +176,7 @@ function App() {
 
       <div className="test-case" id="suffix-icon-input">
         <h4>With suffix icon</h4>
-        <V3DxcInputText
+        <DxcInputText
           label="Input text label"
           suffixIcon={<img src={icon} />}
           value={inputValue}
@@ -186,7 +186,7 @@ function App() {
 
       <div className="test-case" id="assistive-text-input">
         <h4>With assistive text</h4>
-        <V3DxcInputText
+        <DxcInputText
           label="Input text label"
           value={inputValue}
           assistiveText="assistive text"
@@ -196,7 +196,7 @@ function App() {
 
       <div className="test-case" id="invalid-text-input">
         <h4>Invalid input text</h4>
-        <V3DxcInputText
+        <DxcInputText
           label="Input text label"
           value={inputValue}
           assistiveText="assistive text"
@@ -207,7 +207,7 @@ function App() {
 
       <div className="test-case" id="without-label-input">
         <h4>Without label</h4>
-        <V3DxcInputText
+        <DxcInputText
           value={inputValue}
           assistiveText="assistive text"
           onChange={onChange}
@@ -216,12 +216,12 @@ function App() {
 
       <div className="test-case" id="without-assistive-text-label-input">
         <h4>Without assistive text and label</h4>
-        <V3DxcInputText value={inputValue} onChange={onChange} />
+        <DxcInputText value={inputValue} onChange={onChange} />
       </div>
 
       <div className="test-case" id="light-theme">
         <h4>Light theme</h4>
-        <V3DxcInputText
+        <DxcInputText
           label="Input text label"
           value={inputValue}
           assistiveText="assistive text"
@@ -231,7 +231,7 @@ function App() {
 
       <div className="test-case" id="disabled-input">
         <h4>Disabled input text</h4>
-        <V3DxcInputText
+        <DxcInputText
           label="Input text label"
           value={inputValue}
           disabled={true}
@@ -242,7 +242,7 @@ function App() {
 
       <div className="test-case" id="required-input">
         <h4>Required input text</h4>
-        <V3DxcInputText
+        <DxcInputText
           label="Input text label"
           value={inputValue}
           required={true}
@@ -256,7 +256,7 @@ function App() {
         <h4>Sizes</h4>
         <div className="test-case" id="small-single-line-label-text">
           <h5>Small size - Label and assistive text max size single line</h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Label "
             value={inputValue}
             assistiveText="assistive"
@@ -268,7 +268,7 @@ function App() {
           <h5>
             Small size - Label, assistive text and value max size single line
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Label"
             value="Input text"
             assistiveText="assistive"
@@ -280,7 +280,7 @@ function App() {
           <h5>
             Small size - Label, assistive text and value min size single line
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Label i"
             value="Input i"
             assistiveText="assistive t"
@@ -291,7 +291,7 @@ function App() {
 
         <div className="test-case" id="small-max-size-prefix">
           <h5>Small size - Value max size single line with prefix</h5>
-          <V3DxcInputText
+          <DxcInputText
             value="I"
             prefix="pre"
             onClickPrefix={onPrefixClick}
@@ -301,7 +301,7 @@ function App() {
         </div>
         <div className="test-case" id="small-max-size-suffix">
           <h5>Small size - Value max size single line with suffix</h5>
-          <V3DxcInputText
+          <DxcInputText
             value="I"
             suffix="suf"
             onClickSuffix={onSuffixClick}
@@ -313,7 +313,7 @@ function App() {
           <h5>
             Small size - Value max size single line with prefix and suffix
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             value=""
             prefix="pre"
             suffix="suf"
@@ -325,7 +325,7 @@ function App() {
         </div>
         <div className="test-case" id="medium-single-line-label-text">
           <h5>Medium size - Label and assistive text max size single line</h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label input label input lab"
             value={inputValue}
             assistiveText="assistive text assistive text assistive text"
@@ -337,7 +337,7 @@ function App() {
           <h5>
             Medium size - Label, assistive text and value max size single line
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label input label input lab"
             value="Input value input value input val"
             assistiveText="assistive text assistive text assistive text"
@@ -349,7 +349,7 @@ function App() {
           <h5>
             Medium size - Label, assistive text and value min size single line
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label input label input labe"
             value="Input value input value input valu"
             assistiveText="assistive text assistive text assistive text a"
@@ -360,7 +360,7 @@ function App() {
 
         <div className="test-case" id="medium-max-size-prefix">
           <h5>Medium size - Value max size single line with prefix</h5>
-          <V3DxcInputText
+          <DxcInputText
             value="Input value input value inp"
             prefix="pre"
             onClickPrefix={onPrefixClick}
@@ -370,7 +370,7 @@ function App() {
         </div>
         <div className="test-case" id="medium-max-size-suffix">
           <h5>Medium size - Value max size single line with suffix</h5>
-          <V3DxcInputText
+          <DxcInputText
             value="Input value input value inp"
             suffix="suf"
             onClickSuffix={onSuffixClick}
@@ -382,7 +382,7 @@ function App() {
           <h5>
             Medium size - Value max size single line with prefix and suffix
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             value="Input value input valu"
             prefix="pre"
             suffix="suf"
@@ -394,7 +394,7 @@ function App() {
         </div>
         <div className="test-case" id="large-single-line-label-text">
           <h5>Large size - Label and assistive text max size single line</h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label input label input label input label input label input l"
             value={inputValue}
             assistiveText="assistive text assistive text assistive text assistive text assistive text assistive tex"
@@ -406,7 +406,7 @@ function App() {
           <h5>
             Large size - Label, assistive text and value max size single line
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label input label input label input label input label input l"
             value="Input value input value input value input value input value input"
             assistiveText="assistive text assistive text assistive text assistive text assistive text assistive tex"
@@ -418,7 +418,7 @@ function App() {
           <h5>
             Large size - Label, assistive text and value min size single line
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label input label input label input label input label input la"
             value="Input value input value input value input value input value input v"
             assistiveText="assistive text assistive text assistive text assistive text assistive text assistive text"
@@ -429,7 +429,7 @@ function App() {
 
         <div className="test-case" id="large-max-size-prefix">
           <h5>Large size - Value max size single line with prefix</h5>
-          <V3DxcInputText
+          <DxcInputText
             value="Input value input value input value input value input value i"
             prefix="pre"
             onClickPrefix={onPrefixClick}
@@ -439,7 +439,7 @@ function App() {
         </div>
         <div className="test-case" id="large-max-size-suffix">
           <h5>Large size - Value max size single line with suffix</h5>
-          <V3DxcInputText
+          <DxcInputText
             value="Input value input value input value input value input value i"
             suffix="suf"
             onClickSuffix={onSuffixClick}
@@ -451,7 +451,7 @@ function App() {
           <h5>
             Large size - Value max size single line with prefix and suffix
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             value="Input value input value input value input value input v"
             prefix="pre"
             suffix="suf"
@@ -465,7 +465,7 @@ function App() {
           <h5>
             FillParent size - Label and assistive text max size single line
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label example input input input input input input input input input input input input input input input input input input input input input input input input input input input input input input input input i"
             value={inputValue}
             assistiveText="assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistiv"
@@ -478,7 +478,7 @@ function App() {
             FillParent size - Label, assistive text and value max size single
             line
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label example input input input input input input input input input input input input input input input input input input input input input input input input input input input input input input input input i"
             value="Input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value i"
             assistiveText="assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistiv"
@@ -491,7 +491,7 @@ function App() {
             FillParent size - Label, assistive text and value min size single
             line
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label example input input input input input input input input input input input input input input input input input input input input input input input input input input input input input input input input in"
             value="Input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value in"
             assistiveText="assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive text assistive"
@@ -502,7 +502,7 @@ function App() {
 
         <div className="test-case" id="fillParent-max-size-prefix">
           <h5>FillParent size - Value max size single line with prefix</h5>
-          <V3DxcInputText
+          <DxcInputText
             value="Input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input va"
             prefix="pre"
             onClickPrefix={onPrefixClick}
@@ -512,7 +512,7 @@ function App() {
         </div>
         <div className="test-case" id="fillParent-max-size-suffix">
           <h5>FillParent size - Value max size single line with suffix</h5>
-          <V3DxcInputText
+          <DxcInputText
             value="Input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input v"
             suffix="suf"
             onClickSuffix={onSuffixClick}
@@ -524,7 +524,7 @@ function App() {
           <h5>
             FillParent size - Value max size single line with prefix and suffix
           </h5>
-          <V3DxcInputText
+          <DxcInputText
             value="Input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value input value in"
             prefix="pre"
             suffix="suf"
@@ -540,7 +540,7 @@ function App() {
         <h4>Margins</h4>
         <div className="test-case" id="xxsmall-margin">
           <h5>xxsmall margin</h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label"
             value={inputValue}
             assistiveText={"assistive text"}
@@ -551,7 +551,7 @@ function App() {
 
         <div className="test-case" id="xsmall-margin">
           <h5>xsmall margin</h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label"
             value={inputValue}
             assistiveText={"assistive text"}
@@ -562,7 +562,7 @@ function App() {
 
         <div className="test-case" id="small-margin">
           <h5>Small margin</h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label"
             value={inputValue}
             assistiveText={"assistive text"}
@@ -573,7 +573,7 @@ function App() {
 
         <div className="test-case" id="large-margin">
           <h5>Large margin</h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label"
             value={inputValue}
             assistiveText={"assistive text"}
@@ -584,7 +584,7 @@ function App() {
 
         <div className="test-case" id="xlarge-margin">
           <h5>xlarge margin</h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label"
             value={inputValue}
             assistiveText={"assistive text"}
@@ -595,7 +595,7 @@ function App() {
 
         <div className="test-case" id="xxlarge-margin">
           <h5>xxlarge margin</h5>
-          <V3DxcInputText
+          <DxcInputText
             label="Input label"
             value={inputValue}
             assistiveText={"assistive text"}
@@ -607,7 +607,7 @@ function App() {
 
       <div className="test-case" id="async-autocomplete">
         <h4>Asynchronous Autocomplete</h4>
-        <V3DxcInputText
+        <DxcInputText
           label="Asynchronous Autocomplete"
           value={asynchronousAutocompleteValue}
           onChange={onChangeAsynchronousAutocomplete}
@@ -617,7 +617,7 @@ function App() {
       </div>
       <div className="test-case" id="sync-autocomplete">
         <h4>Synchronous Autocomplete</h4>
-        <V3DxcInputText
+        <DxcInputText
           label="Synchronous Autocomplete"
           value={autocompleteValue}
           onChange={onChangeAutocomplete}
@@ -629,7 +629,7 @@ function App() {
       <div className="test-case" id="custom-colors">
         <h4>Custom Autocomplete</h4>
         <ThemeProvider theme={colors}>
-          <V3DxcInputText
+          <DxcInputText
             label="Asynchronous Autocomplete"
             value={asynchronousAutocompleteValue}
             onChange={onChangeAsynchronousAutocomplete}

--- a/docs/src/pages/components/cdk-components/dialog/examples/backgroundCloseDialog.js
+++ b/docs/src/pages/components/cdk-components/dialog/examples/backgroundCloseDialog.js
@@ -2,7 +2,7 @@ import {
   DxcButton,
   DxcDialog,
   DxcHeading,
-  V3DxcInputText,
+  DxcInputText,
 } from "@dxc-technology/halstack-react";
 import { useState } from "react";
 
@@ -17,17 +17,17 @@ const code = `() => {
       <DxcHeading level={4} text="Account information" />
       <DxcHeading level={5} text="Client" margin={{top: "xsmall"}} />
       <div style={{ display: "flex", flexDirection: "column", padding: "35px" }}>
-        <V3DxcInputText
+        <DxcInputText
           label="Name"
           margin={{ bottom: "medium" }}
           size="large"
         />
-        <V3DxcInputText
+        <DxcInputText
           label="Last name"
           margin={{ bottom: "medium" }}
           size="large"
         />
-        <V3DxcInputText
+        <DxcInputText
           label="Address"
           margin={{ bottom: "medium" }}
           size="large"
@@ -57,7 +57,7 @@ const scope = {
   DxcButton,
   DxcDialog,
   DxcHeading,
-  V3DxcInputText,
+  DxcInputText,
 };
 
 export default { code, scope };

--- a/docs/src/pages/components/cdk-components/input-text/examples/autocomplete.js
+++ b/docs/src/pages/components/cdk-components/input-text/examples/autocomplete.js
@@ -1,4 +1,4 @@
-import { V3DxcInputText } from "@dxc-technology/halstack-react";
+import { DxcInputText } from "@dxc-technology/halstack-react";
 import { useState } from "react";
 
 const code = `() => {
@@ -20,7 +20,7 @@ const code = `() => {
   ];
 
   return (
-    <V3DxcInputText
+    <DxcInputText
       label="Autocomplete"
       value={value}
       onChange={onChange}
@@ -31,7 +31,7 @@ const code = `() => {
 }`;
 
 const scope = {
-  V3DxcInputText,
+  DxcInputText,
   useState,
 };
 

--- a/docs/src/pages/components/cdk-components/input-text/examples/controlledInputText.js
+++ b/docs/src/pages/components/cdk-components/input-text/examples/controlledInputText.js
@@ -1,4 +1,4 @@
-import { V3DxcInputText } from "@dxc-technology/halstack-react";
+import { DxcInputText } from "@dxc-technology/halstack-react";
 import { useState } from "react";
 
 const code = `() => {
@@ -8,7 +8,7 @@ const code = `() => {
   };
 
   return (
-    <V3DxcInputText
+    <DxcInputText
       label="Input label"
       assistiveText={"assistive text"}
       value={value}
@@ -19,7 +19,7 @@ const code = `() => {
 }`;
 
 const scope = {
-  V3DxcInputText,
+  DxcInputText,
   useState,
 };
 

--- a/docs/src/pages/components/cdk-components/input-text/examples/darkThemedInputText.js
+++ b/docs/src/pages/components/cdk-components/input-text/examples/darkThemedInputText.js
@@ -1,4 +1,4 @@
-import { V3DxcInputText } from "@dxc-technology/halstack-react";
+import { DxcInputText } from "@dxc-technology/halstack-react";
 import { useState } from "react";
 import suffixPath from "./images/house-24px.svg";
 import prefixPath from "./images/text_fields-24px.svg";
@@ -11,7 +11,7 @@ const code = `() => {
 
   return (
     <div style={{ background: "#000000" }}>
-      <V3DxcInputText
+      <DxcInputText
         label="Input label"
         suffix={"suf"}
         prefix={"pre"}
@@ -26,7 +26,7 @@ const code = `() => {
 }`;
 
 const scope = {
-  V3DxcInputText,
+  DxcInputText,
   useState,
   suffixPath,
   prefixPath,

--- a/docs/src/pages/components/cdk-components/input-text/examples/fillParentInputInputText.js
+++ b/docs/src/pages/components/cdk-components/input-text/examples/fillParentInputInputText.js
@@ -1,4 +1,4 @@
-import { V3DxcInputText } from "@dxc-technology/halstack-react";
+import { DxcInputText } from "@dxc-technology/halstack-react";
 import { useState } from "react";
 
 const code = `() => {
@@ -9,7 +9,7 @@ const code = `() => {
 
   return (
     <div style={{ width: "250px" }}>
-      <V3DxcInputText
+      <DxcInputText
         label="Input label"
         assistiveText={"assistive text"}
         value={value}
@@ -22,7 +22,7 @@ const code = `() => {
 }`;
 
 const scope = {
-  V3DxcInputText,
+  DxcInputText,
   useState,
 };
 

--- a/docs/src/pages/components/cdk-components/input-text/examples/lebeledInputText.js
+++ b/docs/src/pages/components/cdk-components/input-text/examples/lebeledInputText.js
@@ -1,4 +1,4 @@
-import { V3DxcInputText } from "@dxc-technology/halstack-react";
+import { DxcInputText } from "@dxc-technology/halstack-react";
 import { useState } from "react";
 import prefixPath from "./images/text_fields-24px.svg";
 
@@ -10,7 +10,7 @@ const code = `() => {
 
   return (
     <div>
-      <V3DxcInputText
+      <DxcInputText
         label="Input label"
         suffixIcon={
           <svg x="0px" y="0px" viewBox="0 0 24 24" enable-background="new 0 0 24 24">
@@ -28,7 +28,7 @@ const code = `() => {
         onChange={onChange}
         margin="medium"
       />
-      <V3DxcInputText
+      <DxcInputText
         label="Input label"
         suffix={"suf"}
         prefix={"pre"}
@@ -42,7 +42,7 @@ const code = `() => {
 }`;
 
 const scope = {
-  V3DxcInputText,
+  DxcInputText,
   useState,
   prefixPath,
 };

--- a/docs/src/pages/components/cdk-components/input-text/examples/maskedInputText.js
+++ b/docs/src/pages/components/cdk-components/input-text/examples/maskedInputText.js
@@ -1,4 +1,4 @@
-import { V3DxcInputText } from "@dxc-technology/halstack-react";
+import { DxcInputText } from "@dxc-technology/halstack-react";
 import { useState } from "react";
 
 const code = `() => {
@@ -7,7 +7,7 @@ const code = `() => {
   };
 
   return (
-    <V3DxcInputText
+    <DxcInputText
       label="Input label"
       assistiveText={"assistive text"}
       onChange={onChange}
@@ -18,7 +18,7 @@ const code = `() => {
 }`;
 
 const scope = {
-  V3DxcInputText,
+  DxcInputText,
   useState,
 };
 

--- a/docs/src/pages/components/cdk-components/input-text/examples/sizedInputText.js
+++ b/docs/src/pages/components/cdk-components/input-text/examples/sizedInputText.js
@@ -1,4 +1,4 @@
-import { V3DxcInputText } from "@dxc-technology/halstack-react";
+import { DxcInputText } from "@dxc-technology/halstack-react";
 import { useState } from "react";
 
 const code = `() => {
@@ -8,7 +8,7 @@ const code = `() => {
   };
 
   return (
-    <V3DxcInputText
+    <DxcInputText
       label="Input label"
       assistiveText={"assistive text"}
       value={value}
@@ -20,7 +20,7 @@ const code = `() => {
 }`;
 
 const scope = {
-  V3DxcInputText,
+  DxcInputText,
   useState,
 };
 

--- a/docs/src/pages/components/cdk-components/input-text/examples/uncontrolledInputText.js
+++ b/docs/src/pages/components/cdk-components/input-text/examples/uncontrolledInputText.js
@@ -1,4 +1,4 @@
-import { V3DxcInputText } from "@dxc-technology/halstack-react";
+import { DxcInputText } from "@dxc-technology/halstack-react";
 import { useState } from "react";
 
 const code = `() => {
@@ -7,7 +7,7 @@ const code = `() => {
   };
 
   return (
-    <V3DxcInputText
+    <DxcInputText
       label="Input label"
       assistiveText={"assistive text"}
       onChange={onChange}
@@ -17,7 +17,7 @@ const code = `() => {
 }`;
 
 const scope = {
-  V3DxcInputText,
+  DxcInputText,
   useState,
 };
 

--- a/docs/src/pages/themeBuilder/components/previews/Dialog.jsx
+++ b/docs/src/pages/themeBuilder/components/previews/Dialog.jsx
@@ -4,7 +4,7 @@ import {
   DxcDialog,
   DxcButton,
   DxcHeading,
-  V3DxcInputText,
+  DxcInputText,
 } from "@dxc-technology/halstack-react";
 import Mode from "../Mode";
 
@@ -91,13 +91,13 @@ const Dialog = () => {
             <DxcHeading level={4} text="Account information" />
             <DxcHeading level={5} text="Client" margin={{ top: "xsmall" }} />
             <p>
-              <V3DxcInputText label="Name" />
+              <DxcInputText label="Name" />
             </p>
             <p>
-              <V3DxcInputText label="Surname" />
+              <DxcInputText label="Surname" />
             </p>
             <p>
-              <V3DxcInputText label="Address" />
+              <DxcInputText label="Address" />
             </p>
             <p style={{ textAlign: "right" }}>
               <DxcButton

--- a/docs/src/pages/themeBuilder/components/previews/InputText.jsx
+++ b/docs/src/pages/themeBuilder/components/previews/InputText.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import { V3DxcInputText, DxcHeading } from "@dxc-technology/halstack-react";
+import { DxcInputText, DxcHeading } from "@dxc-technology/halstack-react";
 import Mode from "../Mode";
 import facebookIcon from "../../images/FacebookIcon";
 
@@ -58,21 +58,21 @@ const InputText = () => {
         margin={{ top: "xsmall", bottom: "xxsmall" }}
       />
       <Mode text="Default">
-        <V3DxcInputText
+        <DxcInputText
           label="Input label"
           assistiveText={"assistive text"}
           value={value}
           onChange={onChange}
           margin={{ top: "xxsmall", bottom: "xsmall", right: "medium" }}
         />
-        <V3DxcInputText
+        <DxcInputText
           label="Input label"
           suffixIcon={facebookIcon}
           prefixIcon={facebookIcon}
           assistiveText={"assistive text"}
           margin={{ top: "xxsmall", bottom: "xsmall", right: "medium" }}
         />
-        <V3DxcInputText
+        <DxcInputText
           label="Input label"
           suffix={"suf"}
           prefix={"pre"}
@@ -81,7 +81,7 @@ const InputText = () => {
         />
       </Mode>
       <Mode text="Disabled">
-        <V3DxcInputText
+        <DxcInputText
           label="Input label"
           assistiveText={"assistive text"}
           disabled
@@ -89,7 +89,7 @@ const InputText = () => {
         />
       </Mode>
       <Mode text="Required">
-        <V3DxcInputText
+        <DxcInputText
           label="Input label"
           assistiveText={"assistive text"}
           required
@@ -97,7 +97,7 @@ const InputText = () => {
         />
       </Mode>
       <Mode text="Invalid">
-        <V3DxcInputText
+        <DxcInputText
           label="Input label"
           assistiveText={"assistive text"}
           invalid
@@ -105,7 +105,7 @@ const InputText = () => {
         />
       </Mode>
       <Mode text="Autocomplete">
-        <V3DxcInputText
+        <DxcInputText
           label="Autocomplete"
           value={asynchronousAutocompleteValue}
           onChange={onChangeAsynchronousAutocomplete}
@@ -120,21 +120,21 @@ const InputText = () => {
       />
       <BackgroundColorProvider color="#000000">
         <Mode mode="dark" text="Default">
-          <V3DxcInputText
+          <DxcInputText
             label="Input label"
             assistiveText={"assistive text"}
             value={value}
             onChange={onChange}
             margin={{ right: "small", bottom: "small" }}
           />
-          <V3DxcInputText
+          <DxcInputText
             label="Input label"
             suffixIcon={facebookIcon}
             prefixIcon={facebookIcon}
             assistiveText={"assistive text"}
             margin={{ right: "small", bottom: "small" }}
           />
-          <V3DxcInputText
+          <DxcInputText
             label="Input label"
             suffix={"suf"}
             prefix={"pre"}
@@ -143,7 +143,7 @@ const InputText = () => {
           />
         </Mode>
         <Mode mode="dark" text="Disabled">
-          <V3DxcInputText
+          <DxcInputText
             label="Input label"
             assistiveText={"assistive text"}
             disabled
@@ -151,7 +151,7 @@ const InputText = () => {
           />
         </Mode>
         <Mode mode="dark" text="Required">
-          <V3DxcInputText
+          <DxcInputText
             label="Input label"
             assistiveText={"assistive text"}
             required
@@ -159,7 +159,7 @@ const InputText = () => {
           />
         </Mode>
         <Mode mode="dark" text="Invalid">
-          <V3DxcInputText
+          <DxcInputText
             label="Input label"
             assistiveText={"assistive text"}
             invalid
@@ -167,7 +167,7 @@ const InputText = () => {
           />
         </Mode>
         <Mode mode="dark" text="Autocomplete">
-          <V3DxcInputText
+          <DxcInputText
             label="Autocomplete"
             value={asynchronousAutocompleteValue}
             onChange={onChangeAsynchronousAutocomplete}

--- a/lib/src/date/Date.jsx
+++ b/lib/src/date/Date.jsx
@@ -7,7 +7,7 @@ import moment from "moment";
 import DateFnsUtils from "@date-io/date-fns";
 import styled, { ThemeProvider } from "styled-components";
 import PropTypes from "prop-types";
-import V3DxcInputText from "../input-text/InputText";
+import DxcInputText from "../input-text/InputText";
 
 import { spaces } from "../common/variables.js";
 import useTheme from "../useTheme.js";
@@ -234,7 +234,7 @@ const DxcDate = ({
       <MuiThemeProvider theme={dateTheme}>
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
           <StyledDPicker margin={margin}>
-            <V3DxcInputText
+            <DxcInputText
               label={label}
               name={name}
               suffixIcon={calendarSVG}

--- a/lib/src/input-text/InputText.jsx
+++ b/lib/src/input-text/InputText.jsx
@@ -31,7 +31,7 @@ const makeCancelable = (promise) => {
   };
 };
 
-const V3DxcInputText = ({
+const DxcInputText = ({
   label = " ",
   name = "",
   value,
@@ -182,9 +182,7 @@ const V3DxcInputText = ({
           {isError && (
             <MenuItem>
               Error fetching data
-              <ErrorIconContainer>
-                {errorIcon}
-              </ErrorIconContainer>
+              <ErrorIconContainer>{errorIcon}</ErrorIconContainer>
             </MenuItem>
           )}
         </Paper>
@@ -333,7 +331,7 @@ const sizes = {
 
 const ErrorIconContainer = styled.div`
   padding-left: 12px;
-  color:red;
+  color: red;
 `;
 
 const calculateWidth = (margin, size) => {
@@ -703,7 +701,7 @@ const TextContainer = styled.div`
   }
 `;
 
-V3DxcInputText.propTypes = {
+DxcInputText.propTypes = {
   label: PropTypes.string,
   name: PropTypes.string,
   value: PropTypes.string,
@@ -738,4 +736,4 @@ V3DxcInputText.propTypes = {
   tabIndex: PropTypes.number,
 };
 
-export default V3DxcInputText;
+export default DxcInputText;

--- a/lib/src/main.js
+++ b/lib/src/main.js
@@ -8,7 +8,7 @@ import DxcDialog from "./dialog/Dialog";
 import DxcDropdown from "./dropdown/Dropdown";
 import DxcFooter from "./footer/Footer";
 import DxcHeader from "./header/Header";
-import V3DxcInputText from "./input-text/InputText";
+import DxcInputText from "./input-text/InputText";
 import DxcRadio from "./radio/Radio";
 import V3DxcSelect from "./V3Select/V3Select";
 import DxcSlider from "./slider/Slider";
@@ -49,7 +49,7 @@ export {
   DxcFooter,
   DxcCheckbox,
   V3DxcSelect,
-  V3DxcInputText,
+  DxcInputText,
   DxcTextInput,
   DxcDropdown,
   DxcSwitch,

--- a/lib/test/InputText.test.js
+++ b/lib/test/InputText.test.js
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 
 import icon from "../../app/src/images/invision.svg";
 
-import V3DxcInputText from "../src/input-text/InputText";
+import DxcInputText from "../src/input-text/InputText";
 
 const countries = ["Albania", "Andorra", "Armenia", "Austria", "Azerbaijan"];
 
@@ -28,13 +28,13 @@ jest.mock("popper.js", () => {
 
 describe("InputText component tests", () => {
   test("Input renders with correct label", () => {
-    const { getByText } = render(<V3DxcInputText label="Input label" />);
+    const { getByText } = render(<DxcInputText label="Input label" />);
     expect(getByText("Input label")).toBeTruthy();
   });
 
   test("onChange function is called correctly", () => {
     const onChange = jest.fn();
-    const { getByRole } = render(<V3DxcInputText label="Input label" onChange={onChange} />);
+    const { getByRole } = render(<DxcInputText label="Input label" onChange={onChange} />);
     const input = getByRole("textbox");
     userEvent.type(input, "20000");
     expect(onChange).toHaveBeenCalled();
@@ -44,7 +44,7 @@ describe("InputText component tests", () => {
     const onBlur = jest.fn();
     const onChange = jest.fn();
 
-    const { getByRole } = render(<V3DxcInputText label="Input label" onChange={onChange} onBlur={onBlur} />);
+    const { getByRole } = render(<DxcInputText label="Input label" onChange={onChange} onBlur={onBlur} />);
     const input = getByRole("textbox");
     userEvent.type(input, "Test value");
     fireEvent.blur(input);
@@ -54,7 +54,7 @@ describe("InputText component tests", () => {
 
   test("Uncontrolled component", () => {
     const onChange = jest.fn();
-    const { getByRole } = render(<V3DxcInputText label="Input label" onChange={onChange} />);
+    const { getByRole } = render(<DxcInputText label="Input label" onChange={onChange} />);
     const input = getByRole("textbox");
     userEvent.type(input, "20000");
     expect(onChange).toHaveBeenCalled();
@@ -66,7 +66,7 @@ describe("InputText component tests", () => {
     const onChange = jest.fn();
     const onBlur = jest.fn();
     const { getByRole } = render(
-      <V3DxcInputText label="Input label" value="Test value" onChange={onChange} onBlur={onBlur} />
+      <DxcInputText label="Input label" value="Test value" onChange={onChange} onBlur={onBlur} />
     );
     const input = getByRole("textbox");
     userEvent.type(input, "20000");
@@ -78,14 +78,14 @@ describe("InputText component tests", () => {
   });
   test("Prefix icon onClick", () => {
     const onClick = jest.fn();
-    const { getByRole } = render(<V3DxcInputText label="Input label" prefixIconSrc={icon} onClickPrefix={onClick} />);
+    const { getByRole } = render(<DxcInputText label="Input label" prefixIconSrc={icon} onClickPrefix={onClick} />);
     const prefixIcon = getByRole("img");
     userEvent.click(prefixIcon);
     expect(onClick).toHaveBeenCalled();
   });
   test("Suffix icon onClick", () => {
     const onClick = jest.fn();
-    const { getByRole } = render(<V3DxcInputText label="Input label" suffixIconSrc={icon} onClickSuffix={onClick} />);
+    const { getByRole } = render(<DxcInputText label="Input label" suffixIconSrc={icon} onClickSuffix={onClick} />);
     const suffixIcon = getByRole("img");
     userEvent.click(suffixIcon);
     expect(onClick).toHaveBeenCalled();
@@ -96,7 +96,7 @@ describe("Autocomplete component Synchronous tests", () => {
   test("Autocomplete no matches found is shown", async () => {
     const onChangeAtocomplete = jest.fn();
     render(
-      <V3DxcInputText label="Autocomplete Countries" autocompleteOptions={countries} onChange={onChangeAtocomplete} />
+      <DxcInputText label="Autocomplete Countries" autocompleteOptions={countries} onChange={onChangeAtocomplete} />
     );
     const input = screen.getByRole("textbox");
     fireEvent.focus(input);
@@ -108,7 +108,7 @@ describe("Autocomplete component Synchronous tests", () => {
   test("Autocomplete suggestions are shown", async () => {
     const onChangeAtocomplete = jest.fn();
     render(
-      <V3DxcInputText label="Autocomplete Countries" autocompleteOptions={countries} onChange={onChangeAtocomplete} />
+      <DxcInputText label="Autocomplete Countries" autocompleteOptions={countries} onChange={onChangeAtocomplete} />
     );
     const input = screen.getByRole("textbox");
     fireEvent.focus(input);
@@ -118,7 +118,7 @@ describe("Autocomplete component Synchronous tests", () => {
   test("Autocomplete UNCONTROLLED suggestion selected", async () => {
     const onChangeAtocomplete = jest.fn();
     render(
-      <V3DxcInputText label="Autocomplete Countries" autocompleteOptions={countries} onChange={onChangeAtocomplete} />
+      <DxcInputText label="Autocomplete Countries" autocompleteOptions={countries} onChange={onChangeAtocomplete} />
     );
     const input = screen.getByRole("textbox");
     fireEvent.focus(input);
@@ -138,7 +138,7 @@ describe("Autocomplete component Synchronous tests", () => {
   test("Autocomplete CONTROLLED suggestions selected", async () => {
     const onChangeAtocomplete = jest.fn();
     render(
-      <V3DxcInputText
+      <DxcInputText
         label="Autocomplete Countries"
         value="Andorra"
         autocompleteOptions={countries}
@@ -165,11 +165,7 @@ describe("InputText component Asynchronous Autocomplete tests", () => {
 
     const onChangeAtocomplete = jest.fn();
     render(
-      <V3DxcInputText
-        label="Autocomplete Countries"
-        autocompleteOptions={callbackFunc}
-        onChange={onChangeAtocomplete}
-      />
+      <DxcInputText label="Autocomplete Countries" autocompleteOptions={callbackFunc} onChange={onChangeAtocomplete} />
     );
     const input = screen.getByRole("textbox");
     fireEvent.focus(input);
@@ -182,11 +178,7 @@ describe("InputText component Asynchronous Autocomplete tests", () => {
     const callbackFunc = jest.fn(() => new Promise((resolve) => setTimeout(resolve(["Italy", "Spain"]), 1000)));
     const onChangeAtocomplete = jest.fn();
     render(
-      <V3DxcInputText
-        label="Autocomplete Countries"
-        onChange={onChangeAtocomplete}
-        autocompleteOptions={callbackFunc}
-      />
+      <DxcInputText label="Autocomplete Countries" onChange={onChangeAtocomplete} autocompleteOptions={callbackFunc} />
     );
     const input = screen.getByRole("textbox");
     fireEvent.focus(input);
@@ -206,7 +198,7 @@ describe("InputText component Asynchronous Autocomplete tests", () => {
     const callbackFunc = jest.fn(() => new Promise((resolve) => setTimeout(resolve(["Italy", "Spain"]), 3000)));
     const onChangeAtocomplete = jest.fn();
     render(
-      <V3DxcInputText
+      <DxcInputText
         label="Autocomplete Countries"
         value="test value"
         onChange={onChangeAtocomplete}
@@ -232,7 +224,7 @@ describe("InputText component Asynchronous Autocomplete tests", () => {
     const onChangeAtocomplete = jest.fn();
 
     render(
-      <V3DxcInputText
+      <DxcInputText
         label="Autocomplete Countries"
         value="test value"
         onChange={onChangeAtocomplete}


### PR DESCRIPTION
Renamed `V3DxcInputText` to `DxcInputText`, as the new input text component is `DxcTextInput`, so the "V3" is not needed to differentiate.