### PR TITLE
[Patch] Paginator's select is hidden in table.

### DIFF
--- a/lib/src/resultsetTable/ResultsetTable.jsx
+++ b/lib/src/resultsetTable/ResultsetTable.jsx
@@ -211,7 +211,6 @@ const DxcResultsetTableContainer = styled.div`
     props.margin && typeof props.margin === "object" && props.margin.bottom ? spaces[props.margin.bottom] : ""};
   margin-left: ${(props) =>
     props.margin && typeof props.margin === "object" && props.margin.left ? spaces[props.margin.left] : ""};
-  overflow: hidden;
 `;
 
 DxcResultsetTable.propTypes = {


### PR DESCRIPTION
The paginator's select menu is hidden in the ResultsetTable.