### PR TITLE
Fix type comments indicating margin values

### DIFF
--- a/lib/src/alert/types.ts
+++ b/lib/src/alert/types.ts
@@ -38,7 +38,7 @@ type Props = {
    */
   margin?: Space | Margin;
   /**
-   * Size of the component ('small' | 'medium' | 'large' | 'fillParent' | 'fitContent').
+   * Size of the component.
    */
   size?: "small" | "medium" | "large" | "fillParent" | "fitContent";
   /**

--- a/lib/src/card/types.ts
+++ b/lib/src/card/types.ts
@@ -42,15 +42,13 @@ type Props = {
    */
   imageCover?: boolean;
   /**
-   * Size of the margin to be applied to the component. You can pass
-   * an object with 'top', 'bottom', 'left' and 'right' properties
-   * in order to specify different margin sizes.
+   * Size of the margin to be applied to the component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). 
+   * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different margin sizes.
    */
   margin?: Space | Size;
   /**
-   * Size of the padding to be applied to the content area. You can pass
-   * an object with 'top', 'bottom', 'left' and 'right' properties in
-   * order to specify different padding sizes.
+   * Size of the padding to be applied to the content area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). 
+   * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
    */
   contentPadding?: Space | Size;
   /**

--- a/lib/src/checkbox/types.ts
+++ b/lib/src/checkbox/types.ts
@@ -50,7 +50,7 @@ type Props = {
    */
   margin?: Space | Margin;
   /**
-   * Size of the component ('small' | 'medium' | 'large' | 'fillParent' | 'fitContent').
+   * Size of the component.
    */
   size?: "small" | "medium" | "large" | "fillParent" | "fitContent";
   /**

--- a/lib/src/header/types.ts
+++ b/lib/src/header/types.ts
@@ -27,11 +27,13 @@ type Props = {
    */
   onClick?: () => void;
   /**
-   * Size of the bottom margin to be applied to the header.
+   * Size of the bottom margin to be applied to the header 
+   * ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    */
   margin?: Space;
   /**
-   * Size of the padding to be applied to the custom area of the component.
+   * Size of the padding to be applied to the custom area of the component 
+   * ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in
    * order to specify different padding sizes.
    */

--- a/lib/src/radio/types.ts
+++ b/lib/src/radio/types.ts
@@ -43,8 +43,8 @@ type Props = {
    */
   onClick?: (val: boolean) => void;
   /**
-   * Size of the margin to be applied to the component. You can pass an object with 'top',
-   * 'bottom', 'left' and 'right' properties in order to specify different margin sizes.
+   * Size of the margin to be applied to the component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). 
+   * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different margin sizes.
    */
   margin?: Space | Margin;
   /**

--- a/lib/src/tabs/types.ts
+++ b/lib/src/tabs/types.ts
@@ -59,9 +59,8 @@ type Props = {
    */
   onTabHover?: (tabIndex: number) => void;
   /**
-   * Size of the margin to be applied to the component. You can pass an object
-   * with 'top', 'bottom', 'left' and 'right' properties in order to specify
-   * different margin sizes.
+   * Size of the margin to be applied to the component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). 
+   * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different margin sizes.
    */
   margin?: Space | Margin;
   /**


### PR DESCRIPTION
Fix some `types.ts` files that didn't indicate the values of margins and paddings.