### PR TITLE
Several fixes in stories

### DIFF
--- a/lib/src/accordion/Accordion.stories.tsx
+++ b/lib/src/accordion/Accordion.stories.tsx
@@ -301,6 +301,7 @@ export const Chromatic = () => (
           lobortis eget.
         </div>
       </DxcAccordion>
+      <hr />
     </ExampleContainer>
   </>
 );

--- a/lib/src/accordion/Accordion.stories.tsx
+++ b/lib/src/accordion/Accordion.stories.tsx
@@ -125,7 +125,7 @@ export const Chromatic = () => (
     </ExampleContainer>
     <ExampleContainer>
       <Title title="Background color provider over accordion content" theme="light" level={4} />
-      <ThemeProvider advancedTheme={advancedTheme} theme={undefined}>
+      <ThemeProvider advancedTheme={advancedTheme}>
         <DxcAccordion
           label="Dark Accordion"
           isExpanded
@@ -134,7 +134,13 @@ export const Chromatic = () => (
           padding="medium"
         >
           <div style={{ display: "flex", flexDirection: "column" }}>
-            <DxcTextInput label="Label" helperText="HelperText" placeholder="Placeholder" size="fillParent" />
+            <DxcTextInput
+              label="Label"
+              helperText="HelperText"
+              placeholder="Placeholder"
+              size="fillParent"
+              margin={{ bottom: "medium" }}
+            />
             <DxcButton label="Submit" size="medium" />
           </div>
         </DxcAccordion>

--- a/lib/src/accordion/Accordion.tsx
+++ b/lib/src/accordion/Accordion.tsx
@@ -29,7 +29,7 @@ const DxcAccordion = ({
   const colorsTheme = useTheme();
 
   const handleResize = (width) => {
-    (width && width <= responsiveSizes.tablet) ? setIsResponsive(true) : setIsResponsive(false);
+    width && width <= responsiveSizes.tablet ? setIsResponsive(true) : setIsResponsive(false);
   };
 
   const handleEventListener = () => {
@@ -96,7 +96,7 @@ const DxcAccordion = ({
 const calculateWidth = (margin) => `calc(100% - ${getMargin(margin, "left")} - ${getMargin(margin, "right")})`;
 
 const DXCAccordion = styled.div`
-  display: flex;
+  display: inline-flex;
   min-width: 280px;
   margin: ${(props) => (props.margin && typeof props.margin !== "object" ? spaces[props.margin] : "0px")};
   margin-top: ${(props) =>

--- a/lib/src/accordion/Accordion.tsx
+++ b/lib/src/accordion/Accordion.tsx
@@ -138,11 +138,10 @@ const DXCAccordion = styled.div`
       height: 48px;
 
       :focus {
+        outline-color: ${(props) => props.theme.focusBorderColor};
+        outline-style: ${(props) => props.theme.focusBorderStyle};
+        outline-width: ${(props) => props.theme.focusBorderThickness};
         background-color: ${(props) => props.theme.backgroundColor};
-        border-color: ${(props) => props.theme.focusBorderColor};
-        border-radius: ${(props) => props.theme.borderRadius};
-        border-width: ${(props) => props.theme.focusBorderThickness};
-        border-style: ${(props) => props.theme.focusBorderStyle};
       }
       :hover {
         background-color: ${(props) => `${props.theme.hoverBackgroundColor}`};

--- a/lib/src/accordion/Accordion.tsx
+++ b/lib/src/accordion/Accordion.tsx
@@ -96,7 +96,7 @@ const DxcAccordion = ({
 const calculateWidth = (margin) => `calc(100% - ${getMargin(margin, "left")} - ${getMargin(margin, "right")})`;
 
 const DXCAccordion = styled.div`
-  display: inline-flex;
+  display: flex;
   min-width: 280px;
   margin: ${(props) => (props.margin && typeof props.margin !== "object" ? spaces[props.margin] : "0px")};
   margin-top: ${(props) =>

--- a/lib/src/accordion/Accordion.tsx
+++ b/lib/src/accordion/Accordion.tsx
@@ -138,10 +138,11 @@ const DXCAccordion = styled.div`
       height: 48px;
 
       :focus {
-        outline-color: ${(props) => props.theme.focusBorderColor};
-        outline-style: ${(props) => props.theme.focusBorderStyle};
-        outline-width: ${(props) => props.theme.focusBorderThickness};
         background-color: ${(props) => props.theme.backgroundColor};
+        border-color: ${(props) => props.theme.focusBorderColor};
+        border-radius: ${(props) => props.theme.borderRadius};
+        border-width: ${(props) => props.theme.focusBorderThickness};
+        border-style: ${(props) => props.theme.focusBorderStyle};
       }
       :hover {
         background-color: ${(props) => `${props.theme.hoverBackgroundColor}`};

--- a/lib/src/card/Card.stories.tsx
+++ b/lib/src/card/Card.stories.tsx
@@ -174,7 +174,7 @@ const actionCard = () => (
       <Title title="Focused default with action" theme="light" level={4} />
       <DxcCard onClick={() => {}}>Focused default with action</DxcCard>
     </ExampleContainer>
-    <ExampleContainer>
+    <ExampleContainer expanded>
       <Title title="Hovered default with action" theme="light" level={4} />
       <DxcCard onClick={() => {}}>Hovered default with action</DxcCard>
     </ExampleContainer>

--- a/lib/src/file-input/FileInput.stories.tsx
+++ b/lib/src/file-input/FileInput.stories.tsx
@@ -501,6 +501,7 @@ export const Chromatic = () => (
         mode="dropzone"
         margin="xxlarge"
       />
+      <hr />
     </ExampleContainer>
   </>
 );

--- a/lib/src/file-input/FileInput.stories.tsx
+++ b/lib/src/file-input/FileInput.stories.tsx
@@ -65,6 +65,18 @@ const filesExamples = [
 
 export const Chromatic = () => (
   <>
+    <ExampleContainer pseudoState="pseudo-hover">
+      <Title title="File item hovered" theme="light" level={4} />
+      <DxcFileInput value={fileExample} callbackFile={() => {}} />
+    </ExampleContainer>
+    <ExampleContainer pseudoState="pseudo-focus">
+      <Title title="File item focused" theme="light" level={4} />
+      <DxcFileInput value={fileExample} callbackFile={() => {}} />
+    </ExampleContainer>
+    <ExampleContainer pseudoState="pseudo-active">
+      <Title title="File item actived" theme="light" level={4} />
+      <DxcFileInput value={fileExample} callbackFile={() => {}} />
+    </ExampleContainer>
     <Title title="File" theme="light" level={2} />
     <ExampleContainer>
       <Title title="Without label" theme="light" level={4} />
@@ -489,18 +501,7 @@ export const Chromatic = () => (
         mode="dropzone"
         margin="xxlarge"
       />
-    </ExampleContainer>
-    <ExampleContainer pseudoState="pseudo-hover">
-      <Title title="File item hovered" theme="light" level={4} />
-      <DxcFileInput value={fileExample} callbackFile={() => {}} />
-    </ExampleContainer>
-    <ExampleContainer pseudoState="pseudo-focus">
-      <Title title="File item focused" theme="light" level={4} />
-      <DxcFileInput value={fileExample} callbackFile={() => {}} />
-    </ExampleContainer>
-    <ExampleContainer pseudoState="pseudo-active">
-      <Title title="File item actived" theme="light" level={4} />
-      <DxcFileInput value={fileExample} callbackFile={() => {}} />
+      <hr />
     </ExampleContainer>
   </>
 );

--- a/lib/src/file-input/FileInput.stories.tsx
+++ b/lib/src/file-input/FileInput.stories.tsx
@@ -65,18 +65,6 @@ const filesExamples = [
 
 export const Chromatic = () => (
   <>
-    <ExampleContainer pseudoState="pseudo-hover">
-      <Title title="File item hovered" theme="light" level={4} />
-      <DxcFileInput value={fileExample} callbackFile={() => {}} />
-    </ExampleContainer>
-    <ExampleContainer pseudoState="pseudo-focus">
-      <Title title="File item focused" theme="light" level={4} />
-      <DxcFileInput value={fileExample} callbackFile={() => {}} />
-    </ExampleContainer>
-    <ExampleContainer pseudoState="pseudo-active">
-      <Title title="File item actived" theme="light" level={4} />
-      <DxcFileInput value={fileExample} callbackFile={() => {}} />
-    </ExampleContainer>
     <Title title="File" theme="light" level={2} />
     <ExampleContainer>
       <Title title="Without label" theme="light" level={4} />
@@ -501,7 +489,18 @@ export const Chromatic = () => (
         mode="dropzone"
         margin="xxlarge"
       />
-      <hr />
+    </ExampleContainer>
+    <ExampleContainer pseudoState="pseudo-hover">
+      <Title title="File item hovered" theme="light" level={4} />
+      <DxcFileInput value={fileExample} callbackFile={() => {}} />
+    </ExampleContainer>
+    <ExampleContainer pseudoState="pseudo-focus">
+      <Title title="File item focused" theme="light" level={4} />
+      <DxcFileInput value={fileExample} callbackFile={() => {}} />
+    </ExampleContainer>
+    <ExampleContainer pseudoState="pseudo-active">
+      <Title title="File item actived" theme="light" level={4} />
+      <DxcFileInput value={fileExample} callbackFile={() => {}} />
     </ExampleContainer>
   </>
 );

--- a/lib/src/heading/Heading.stories.tsx
+++ b/lib/src/heading/Heading.stories.tsx
@@ -48,6 +48,7 @@ export const Chromatic = () => (
       <DxcHeading text="Xlarge" margin="xlarge" />
       <Title title="Xxlarge" theme="light" level={4} />
       <DxcHeading text="Xxlarge" margin="xxlarge" />
+      <hr />
     </ExampleContainer>
   </>
 );

--- a/lib/src/heading/Heading.stories.tsx
+++ b/lib/src/heading/Heading.stories.tsx
@@ -28,9 +28,9 @@ export const Chromatic = () => (
       <Title title="'light' Weight" theme="light" level={4} />
       <DxcHeading text="Heading for sections within the page" level={2} weight="light" />
       <Title title="'normal' Weight" theme="light" level={4} />
-      <DxcHeading text="Heading for sections within the page" level={4} weight="normal" />
+      <DxcHeading text="Heading for sections within the page" level={2} weight="normal" />
       <Title title="'bold' Weight" theme="light" level={4} />
-      <DxcHeading text="Heading for sections within the page" weight="bold" />
+      <DxcHeading text="Heading for sections within the page" level={2} weight="bold" />
     </ExampleContainer>
     <Title title="Margins" theme="light" level={2} />
     <ExampleContainer>

--- a/lib/src/layout/ApplicationLayout.tsx
+++ b/lib/src/layout/ApplicationLayout.tsx
@@ -27,7 +27,7 @@ const Footer = ({ children }: AppLayoutFooterPropsType): JSX.Element => {
 };
 
 const SideNav = (props): JSX.Element => {
-  const { displayArrow=true, mode="overlay", ...childProps }: AppLayoutSidenavPropsType = props;
+  const { displayArrow = true, mode = "overlay", ...childProps }: AppLayoutSidenavPropsType = props;
   return <DxcSidenav {...childProps}>{childProps.children}</DxcSidenav>;
 };
 
@@ -258,6 +258,9 @@ const ArrowTrigger = styled.div`
   cursor: pointer;
   & > svg {
     fill: ${(props) => props.theme.arrowColor};
+  }
+  :focus {
+    outline: #0095ff auto 1px;
   }
 `;
 

--- a/lib/src/link/Link.stories.tsx
+++ b/lib/src/link/Link.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import DxcLink from "./Link";
 import Title from "../../.storybook/components/Title";
 import ExampleContainer from "../../.storybook/components/ExampleContainer";
+import styled from "styled-components";
 
 export default {
   title: "Link",
@@ -141,6 +142,15 @@ export const Chromatic = () => (
       <DxcLink text="Test" margin="xlarge" href="https://www.linkedin.com/"></DxcLink>
       <Title title="Xxlarge margin" theme="light" level={4} />
       <DxcLink text="Test" margin="xxlarge" href="https://www.linkedin.com/"></DxcLink>
+      <StyledDiv></StyledDiv>
     </ExampleContainer>
   </>
 );
+
+const StyledDiv = styled.div`
+  background: red;
+  border-radius: 2px;
+  outline: blue solid 2px;
+  width: 100px;
+  height: 100px;
+`;

--- a/lib/src/link/Link.stories.tsx
+++ b/lib/src/link/Link.stories.tsx
@@ -151,6 +151,6 @@ const StyledDiv = styled.div`
   background: red;
   border-radius: 2px;
   outline: blue solid 2px;
-  width: 100px;
-  height: 100px;
+  width: 120px;
+  height: 120px;
 `;

--- a/lib/src/link/Link.stories.tsx
+++ b/lib/src/link/Link.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import DxcLink from "./Link";
 import Title from "../../.storybook/components/Title";
 import ExampleContainer from "../../.storybook/components/ExampleContainer";
-import styled from "styled-components";
 
 export default {
   title: "Link",

--- a/lib/src/link/Link.stories.tsx
+++ b/lib/src/link/Link.stories.tsx
@@ -142,15 +142,6 @@ export const Chromatic = () => (
       <DxcLink text="Test" margin="xlarge" href="https://www.linkedin.com/"></DxcLink>
       <Title title="Xxlarge margin" theme="light" level={4} />
       <DxcLink text="Test" margin="xxlarge" href="https://www.linkedin.com/"></DxcLink>
-      <StyledDiv></StyledDiv>
     </ExampleContainer>
   </>
 );
-
-const StyledDiv = styled.div`
-  background: red;
-  border-radius: 2px;
-  outline: blue solid 2px;
-  width: 120px;
-  height: 120px;
-`;

--- a/lib/src/password-input/PasswordInput.stories.tsx
+++ b/lib/src/password-input/PasswordInput.stories.tsx
@@ -53,7 +53,7 @@ export const Chromatic = () => (
     <Title title="Margins" theme="light" level={2} />
     <ExampleContainer>
       <Title title="Xxsmall margin" theme="light" level={4} />
-      <DxcPasswordInput label="Xxsmmall" margin="xxsmall" />
+      <DxcPasswordInput label="Xxsmall" margin="xxsmall" />
     </ExampleContainer>
     <ExampleContainer>
       <Title title="Xsmall margin" theme="light" level={4} />
@@ -100,7 +100,7 @@ export const Chromatic = () => (
 );
 
 const Password = () => (
-  <ExampleContainer>
+  <ExampleContainer expanded>
     <Title title="Show password" theme="light" level={4} />
     <DxcPasswordInput label="Password input" value="Password" />
   </ExampleContainer>
@@ -108,7 +108,7 @@ const Password = () => (
 const PasswordDark = () => (
   <BackgroundColorProvider color="#333333">
     <DarkContainer>
-      <ExampleContainer>
+      <ExampleContainer expanded>
         <Title title="Show password" theme="dark" level={4} />
         <DxcPasswordInput label="Password input" value="Password" />
       </ExampleContainer>

--- a/lib/src/resultsetTable/ResultsetTable.stories.tsx
+++ b/lib/src/resultsetTable/ResultsetTable.stories.tsx
@@ -216,6 +216,7 @@ export const Chromatic = () => (
     <ExampleContainer>
       <Title title="Xxlarge" theme="light" level={4} />
       <DxcResultsetTable columns={columns} rows={rows} margin={"xxlarge"}></DxcResultsetTable>
+      <hr />
     </ExampleContainer>
   </>
 );

--- a/lib/src/resultsetTable/ResultsetTable.tsx
+++ b/lib/src/resultsetTable/ResultsetTable.tsx
@@ -198,6 +198,9 @@ const HeaderContainer = styled.div`
       ? "flex-end"
       : "flex-start"};
   width: 100%;
+  :focus {
+    outline: #0095ff auto 1px;
+  }
 `;
 const HeaderRow = styled.thead`
   height: 60px;

--- a/lib/src/sidenav/Sidenav.stories.tsx
+++ b/lib/src/sidenav/Sidenav.stories.tsx
@@ -143,7 +143,24 @@ export const Chromatic = () => (
             gravida enim. Donec rhoncus aliquam nisl, ac cursus enim bibendum vitae. Nunc sit amet elit ornare,
             malesuada urna eu, fringilla mauris. Vivamus bibendum turpis est, id elementum purus euismod sit amet. Etiam
             sit amet maximus augue. Vivamus erat sapien, ultricies fringilla tellus id, condimentum blandit justo.
-            Praesent quis nunc dignissim, pharetra neque molestie, molestie lectus.
+            Praesent quis nunc dignissim, pharetra neque molestie, molestie lectus. Lorem ipsum dolor sit amet,
+            consectetur adipiscing elit. Morbi egestas luctus porttitor. Donec massa magna, placerat sit amet felis
+            eget, venenatis fringilla ipsum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec congue
+            laoreet orci, nec elementum dolor consequat quis. Curabitur rhoncus justo sed dapibus tincidunt. Vestibulum
+            cursus ut risus sit amet congue. Nunc luctus, urna ullamcorper facilisis Jia Le, risus eros aliquam erat, ut
+            efficitur ante neque id odio. Nam orci leo, dignissim sit amet dolor ut, congue gravida enim. Donec rhoncus
+            aliquam nisl, ac cursus enim bibendum vitae. Nunc sit amet elit ornare, malesuada urna eu, fringilla mauris.
+            Vivamus bibendum turpis est, id elementum purus euismod sit amet. Etiam sit amet maximus augue. Vivamus erat
+            sapien, ultricies fringilla tellus id, condimentum blandit justo. Praesent quis nunc dignissim, pharetra
+            neque molestie, molestie lectus.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi egestas
+            luctus porttitor. Donec massa magna, placerat sit amet felis eget, venenatis fringilla ipsum. Lorem ipsum
+            dolor sit amet, consectetur adipiscing elit. Donec congue laoreet orci, nec elementum dolor consequat quis.
+            Curabitur rhoncus justo sed dapibus tincidunt. Vestibulum cursus ut risus sit amet congue. Nunc luctus, urna
+            ullamcorper facilisis Jia Le, risus eros aliquam erat, ut efficitur ante neque id odio. Nam orci leo,
+            dignissim sit amet dolor ut, congue gravida enim. Donec rhoncus aliquam nisl, ac cursus enim bibendum vitae.
+            Nunc sit amet elit ornare, malesuada urna eu, fringilla mauris. Vivamus bibendum turpis est, id elementum
+            purus euismod sit amet. Etiam sit amet maximus augue. Vivamus erat sapien, ultricies fringilla tellus id,
+            condimentum blandit justo. Praesent quis nunc dignissim, pharetra neque molestie, molestie lectus.
           </p>
         </DxcSidenav>
       </StyledContainer>

--- a/lib/src/spinner/Spinner.stories.jsx
+++ b/lib/src/spinner/Spinner.stories.jsx
@@ -62,6 +62,7 @@ export const Chromatic = () => (
       <DxcSpinner margin="xlarge" mode="small" value="75"></DxcSpinner>
       <Title title="Xxlarge margin" theme="light" level={4} />
       <DxcSpinner margin="xxlarge" mode="small" value="75"></DxcSpinner>
+      <hr />
     </ExampleContainer>
   </>
 );

--- a/lib/src/switch/Switch.stories.tsx
+++ b/lib/src/switch/Switch.stories.tsx
@@ -72,7 +72,7 @@ export const Chromatic = () => (
     <Title title="Margins" theme="light" level={2} />
     <ExampleContainer>
       <Title title="Xxsmall margin" theme="light" level={4} />
-      <DxcSwitch label="Xxsmmall" margin="xxsmall" />
+      <DxcSwitch label="Xxsmall" margin="xxsmall" />
     </ExampleContainer>
     <ExampleContainer>
       <Title title="Xsmall margin" theme="light" level={4} />

--- a/lib/src/table/Table.stories.jsx
+++ b/lib/src/table/Table.stories.jsx
@@ -271,6 +271,7 @@ export const Chromatic = () => (
           <td>Cell 9</td>
         </tr>
       </DxcTable>
+      <hr />
     </ExampleContainer>
   </>
 );

--- a/lib/src/tabs/Tabs.stories.tsx
+++ b/lib/src/tabs/Tabs.stories.tsx
@@ -116,6 +116,7 @@ export const Chromatic = () => (
     <ExampleContainer>
       <Title title="Xxlarge margin" theme="light" level={4} />
       <DxcTabs tabs={tabs} margin="xxlarge" />
+      <hr />
     </ExampleContainer>
   </>
 );

--- a/lib/src/tag/Tag.stories.tsx
+++ b/lib/src/tag/Tag.stories.tsx
@@ -132,7 +132,7 @@ export const Chromatic = () => (
 );
 
 const LinkTag = () => (
-  <ExampleContainer>
+  <ExampleContainer expanded>
     <Title title="Hover link tag" theme="light" level={4} />
     <DxcTag label="Tag" icon={icon} linkHref="https://www.dxc.com" />
   </ExampleContainer>

--- a/lib/src/text-input/TextInput.stories.tsx
+++ b/lib/src/text-input/TextInput.stories.tsx
@@ -262,14 +262,14 @@ export const Chromatic = () => (
 );
 
 const FocusedActionTextInput = () => (
-  <ExampleContainer>
+  <ExampleContainer expanded>
     <Title title="Focused action" theme="light" level={4} />
     <DxcTextInput label="Text input" action={action} clearable />
   </ExampleContainer>
 );
 
 const ActivedActionTextInput = () => (
-  <ExampleContainer pseudoState="pseudo-active">
+  <ExampleContainer pseudoState="pseudo-active" expanded>
     <Title title="Actived action" theme="light" level={4} />
     <DxcTextInput label="Text input" action={action} clearable />
   </ExampleContainer>
@@ -306,7 +306,7 @@ const ActivedOptionAutosuggest = () => (
 const FocusedActionTextInputOnDark = () => (
   <BackgroundColorProvider color="#333333">
     <DarkContainer>
-      <ExampleContainer>
+      <ExampleContainer expanded>
         <Title title="Focused action" theme="dark" level={4} />
         <DxcTextInput label="Text input" action={action} clearable />
       </ExampleContainer>
@@ -317,7 +317,7 @@ const FocusedActionTextInputOnDark = () => (
 const ActivedActionTextInputOnDark = () => (
   <BackgroundColorProvider color="#333333">
     <DarkContainer>
-      <ExampleContainer pseudoState="pseudo-active">
+      <ExampleContainer pseudoState="pseudo-active" expanded>
         <Title title="Actived action" theme="dark" level={4} />
         <DxcTextInput label="Text input" action={action} clearable />
       </ExampleContainer>

--- a/lib/src/textarea/Textarea.stories.jsx
+++ b/lib/src/textarea/Textarea.stories.jsx
@@ -105,15 +105,15 @@ export const Chromatic = () => (
     <Title title="Margins" theme="light" level={2} />
     <ExampleContainer>
       <Title title="Xxsmall margin" theme="light" level={4} />
-      <DxcTextarea label="Xxsmmall" margin="xxsmall" />
+      <DxcTextarea label="Xxsmall" margin="xxsmall" />
     </ExampleContainer>
     <ExampleContainer>
       <Title title="Xsmall margin" theme="light" level={4} />
-      <DxcTextarea label="xsmmall" margin="xsmall" />
+      <DxcTextarea label="xsmall" margin="xsmall" />
     </ExampleContainer>
     <ExampleContainer>
       <Title title="Small margin" theme="light" level={4} />
-      <DxcTextarea label="smmall" margin="small" />
+      <DxcTextarea label="small" margin="small" />
     </ExampleContainer>
     <ExampleContainer>
       <Title title="Medium margin" theme="light" level={4} />

--- a/lib/src/textarea/Textarea.stories.jsx
+++ b/lib/src/textarea/Textarea.stories.jsx
@@ -130,6 +130,7 @@ export const Chromatic = () => (
     <ExampleContainer>
       <Title title="Xxlarge margin" theme="light" level={4} />
       <DxcTextarea label="Xxlarge" margin="xxlarge" />
+      <hr />
     </ExampleContainer>
   </>
 );


### PR DESCRIPTION
- Fix dark test of the accordion.
- Added `expanded` prop to the `ExampleContainer` since some components were not seen in its entirety in the snapshots.
- Change some `smmall` titles to `small`.
- Added `< hr/>` in some stories in order to get the snapshot of the whole component with margin.
- Added `focus` to the arrow of the application layout.
- Added `focus` to the sortable heading in resultset table.
- Change in `Heading` `weight` tests.