### PR TITLE
[Major] Update gutter scale in row and stack components

### DIFF
--- a/lib/src/list/List.stories.tsx
+++ b/lib/src/list/List.stories.tsx
@@ -41,6 +41,11 @@ export const Chromatic = () => (
         <DxcText>Text 2.</DxcText>
       </DxcList>
     </Container>
+    <Title title="gutter = xxxsmall" theme="light" level={4} />
+    <DxcList gutter="xxsmall">
+      <DxcText>Text 1.</DxcText>
+      <DxcText>Text 2.</DxcText>
+    </DxcList>
     <Title title="gutter = xxsmall" theme="light" level={4} />
     <DxcList gutter="xxsmall">
       <DxcText>Text 1.</DxcText>
@@ -73,6 +78,11 @@ export const Chromatic = () => (
     </DxcList>
     <Title title="gutter = xxlarge" theme="light" level={4} />
     <DxcList gutter="xxlarge">
+      <DxcText>Text 1.</DxcText>
+      <DxcText>Text 2.</DxcText>
+    </DxcList>
+    <Title title="gutter = xxxlarge" theme="light" level={4} />
+    <DxcList gutter="xxxlarge">
       <DxcText>Text 1.</DxcText>
       <DxcText>Text 2.</DxcText>
     </DxcList>

--- a/lib/src/list/List.tsx
+++ b/lib/src/list/List.tsx
@@ -5,7 +5,7 @@ import DxcText from "../text/Text";
 
 type ListProps = {
   children: React.ReactNode;
-  gutter?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge";
+  gutter?: "none" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge";
   type?: "disc" | "circle" | "square" | "number";
 };
 

--- a/lib/src/list/List.tsx
+++ b/lib/src/list/List.tsx
@@ -9,7 +9,7 @@ type ListProps = {
   type?: "disc" | "circle" | "square" | "number";
 };
 
-function List({ children, type = "disc", gutter = "xsmall" }: ListProps) {
+function List({ children, type = "disc", gutter = "xxsmall" }: ListProps) {
   return (
     <DxcStack as={type === "number" ? "ol" : "ul"} gutter={gutter}>
       {React.Children.map(children, (child, index) => {

--- a/lib/src/row/Row.stories.tsx
+++ b/lib/src/row/Row.stories.tsx
@@ -106,6 +106,14 @@ export const Chromatic = () => (
         <Placeholder paddingTop={60}></Placeholder>
       </DxcRow>
     </Container>
+     <Title title="gutter = xxxsmall" theme="light" level={4} />
+    <Container>
+      <DxcRow gutter="xxxsmall">
+        <Placeholder></Placeholder>
+        <Placeholder></Placeholder>
+        <Placeholder></Placeholder>
+      </DxcRow>
+    </Container>
     <Title title="gutter = xxsmall" theme="light" level={4} />
     <Container>
       <DxcRow gutter="xxsmall">

--- a/lib/src/row/Row.stories.tsx
+++ b/lib/src/row/Row.stories.tsx
@@ -170,6 +170,14 @@ export const Chromatic = () => (
         <Placeholder></Placeholder>
       </DxcRow>
     </Container>
+    <Title title="gutter = xxxlarge" theme="light" level={4} />
+    <Container>
+      <DxcRow gutter="xxxlarge">
+        <Placeholder></Placeholder>
+        <Placeholder></Placeholder>
+        <Placeholder></Placeholder>
+      </DxcRow>
+    </Container>
     <Title title="gutter = none" theme="light" level={4} />
     <Container>
       <DxcRow gutter="none">

--- a/lib/src/row/Row.tsx
+++ b/lib/src/row/Row.tsx
@@ -59,22 +59,24 @@ const StyledRow = styled.div`
     switch (gutter) {
       case "none":
         return "0";
-      case "xxsmall":
+      case "xxxsmall":
         return "0.125rem";
-      case "xsmall":
+      case "xxsmall":
         return "0.25rem";
-      case "small":
+      case "xsmall":
         return "0.5rem";
-      case "medium":
+      case "small":
         return "1rem";
-      case "large":
+      case "medium":
         return "1.5rem";
-      case "xlarge":
+      case "large":
         return "2rem";
-      case "xxlarge":
+      case "xlarge":
         return "3rem";
-      case "xxxlarge":
+      case "xxlarge":
         return "4rem";
+      case "xxxlarge":
+        return "5rem";
       default:
         return "0";
     }

--- a/lib/src/row/Row.tsx
+++ b/lib/src/row/Row.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 type RowProps = {
-  gutter?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge";
+  gutter?: "none" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge";
   align?: "start" | "center" | "end" | "baseline" | "stretch";
   justify?: "start" | "center" | "end" | "spaceBetween" | "spaceAround" | "spaceEvenly";
   wrap?: boolean;

--- a/lib/src/stack/Stack.stories.tsx
+++ b/lib/src/stack/Stack.stories.tsx
@@ -58,6 +58,14 @@ export const Chromatic = () => (
         <Placeholder paddingLeft={60}></Placeholder>
       </DxcStack>
     </Container>
+    <Title title="gutter = xxxsmall" theme="light" level={4} />
+    <Container>
+      <DxcStack gutter="xxxsmall">
+        <Placeholder></Placeholder>
+        <Placeholder></Placeholder>
+        <Placeholder></Placeholder>
+      </DxcStack>
+    </Container>
     <Title title="gutter = xxsmall" theme="light" level={4} />
     <Container>
       <DxcStack gutter="xxsmall">

--- a/lib/src/stack/Stack.stories.tsx
+++ b/lib/src/stack/Stack.stories.tsx
@@ -122,6 +122,14 @@ export const Chromatic = () => (
         <Placeholder></Placeholder>
       </DxcStack>
     </Container>
+    <Title title="gutter = xxxlarge" theme="light" level={4} />
+    <Container>
+      <DxcStack gutter="xxxlarge">
+        <Placeholder></Placeholder>
+        <Placeholder></Placeholder>
+        <Placeholder></Placeholder>
+      </DxcStack>
+    </Container>
     <Title title="gutter = xxlarge && divider" theme="light" level={4} />
     <Container>
       <DxcStack gutter="xxlarge" divider>

--- a/lib/src/stack/Stack.tsx
+++ b/lib/src/stack/Stack.tsx
@@ -52,22 +52,24 @@ const StyledStack = styled.div`
     switch (gutter) {
       case "none":
         return "0";
-      case "xxsmall":
+      case "xxxsmall":
         return `calc(0.125rem / ${divider ? 2 : 1})`;
-      case "xsmall":
+      case "xxsmall":
         return `calc(0.25rem / ${divider ? 2 : 1})`;
-      case "small":
+      case "xsmall":
         return `calc(0.5rem / ${divider ? 2 : 1})`;
-      case "medium":
+      case "small":
         return `calc(1rem / ${divider ? 2 : 1})`;
-      case "large":
+      case "medium":
         return `calc(1.5rem / ${divider ? 2 : 1})`;
-      case "xlarge":
+      case "large":
         return `calc(2rem / ${divider ? 2 : 1})`;
-      case "xxlarge":
+      case "xlarge":
         return `calc(3rem / ${divider ? 2 : 1})`;
-      case "xxxlarge":
+      case "xxlarge":
         return `calc(4rem / ${divider ? 2 : 1})`;
+      case "xxxlarge":
+        return `calc(5rem / ${divider ? 2 : 1})`;
       default:
         return "0";
     }

--- a/lib/src/stack/Stack.tsx
+++ b/lib/src/stack/Stack.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 type StackProps = {
-  gutter?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge";
+  gutter?: "none" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge";
   divider?: boolean;
   align?: "start" | "center" | "end" | "baseline" | "stretch";
   as?: React.ElementType;


### PR DESCRIPTION
## Changes

* Change `gutter` scale in `stack` and `row` components to allow bigger values 
* Add `xxxsmall` value to the scale
* Update list component default `gutter` in order to keep the same spacing value

Closes #749 