### PR TITLE
[Patch] Reorder elements rendered in components

### DIFF
--- a/lib/src/accordion/Accordion.tsx
+++ b/lib/src/accordion/Accordion.tsx
@@ -28,7 +28,7 @@ const DxcAccordion = ({
   const colorsTheme = useTheme();
 
   const handleResize = (width) => {
-    (width && width <= responsiveSizes.tablet) ? setIsResponsive(true) : setIsResponsive(false);
+    width && width <= responsiveSizes.tablet ? setIsResponsive(true) : setIsResponsive(false);
   };
 
   const handleEventListener = () => {
@@ -68,7 +68,6 @@ const DxcAccordion = ({
         >
           <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />} tabIndex={disabled ? -1 : tabIndex}>
             <AccordionInfo disabled={disabled}>
-              <AccordionLabel>{label}</AccordionLabel>
               {icon ? (
                 <IconContainer disabled={disabled}>
                   {typeof icon === "object" ? icon : React.createElement(icon)}
@@ -76,6 +75,7 @@ const DxcAccordion = ({
               ) : (
                 iconSrc && <AccordionIcon src={iconSrc} />
               )}
+              <AccordionLabel>{label}</AccordionLabel>
             </AccordionInfo>
             {assistiveText && <AccordionAssistiveText disabled={disabled}>{assistiveText}</AccordionAssistiveText>}
           </ExpansionPanelSummary>
@@ -216,7 +216,6 @@ const DXCAccordion = styled.div`
 
 const AccordionInfo = styled.div`
   display: flex;
-  flex-direction: row-reverse;
   align-items: center;
   padding-left: ${(props) => props.theme.titlePaddingLeft};
   padding-right: ${(props) => props.theme.titlePaddingRight};

--- a/lib/src/button/Button.tsx
+++ b/lib/src/button/Button.tsx
@@ -22,6 +22,13 @@ const DxcButton = ({
 }: ButtonPropsType): JSX.Element => {
   const colorsTheme = useTheme();
   const backgroundType = useContext(BackgroundColorContext);
+
+  const labelComponent = (
+    <LabelContainer icon={icon} iconPosition={iconPosition}>
+      {label}
+    </LabelContainer>
+  );
+
   return (
     <ThemeProvider theme={colorsTheme.button}>
       <DxCButton
@@ -44,11 +51,7 @@ const DxcButton = ({
             onClick();
           }}
         >
-          {label && (
-            <LabelContainer icon={icon} iconPosition={iconPosition}>
-              {label}
-            </LabelContainer>
-          )}
+          {label && iconPosition === "after" && labelComponent}
           {icon ? (
             <IconContainer label={label} iconPosition={iconPosition}>
               {typeof icon === "object" ? icon : React.createElement(icon)}
@@ -56,6 +59,7 @@ const DxcButton = ({
           ) : (
             iconSrc && <ButtonIcon label={label} iconPosition={iconPosition} src={iconSrc} />
           )}
+          {label && iconPosition === "before" && labelComponent}
         </Button>
       </DxCButton>
     </ThemeProvider>
@@ -134,7 +138,6 @@ const DxCButton = styled.div`
 
     .MuiButton-label {
       display: flex;
-      flex-direction: ${(props) => (props.iconPosition === "after" && "row") || "row-reverse"};
       align-items: center;
     }
 

--- a/lib/src/card/Card.tsx
+++ b/lib/src/card/Card.tsx
@@ -24,16 +24,19 @@ const DxcCard = ({
 
   const [isHovered, changeIsHovered] = useState(false);
 
+  const imageComponent = (
+    <ImageContainer imageBgColor={imageBgColor}>
+      <TagImage imagePadding={imagePadding} cover={imageCover} src={imageSrc}></TagImage>
+    </ImageContainer>
+  );
+
   const tagContent = (
     <DxcBox shadowDepth={!outlined ? 0 : isHovered && (onClick || linkHref) ? 2 : 1}>
       <ThemeProvider theme={colorsTheme.card}>
         <CardContainer hasAction={onClick || linkHref} imagePosition={imagePosition}>
-          {imageSrc && (
-            <ImageContainer imageBgColor={imageBgColor}>
-              <TagImage imagePadding={imagePadding} cover={imageCover} src={imageSrc}></TagImage>
-            </ImageContainer>
-          )}
+          {imageSrc && imagePosition === "before" && imageComponent}
           <CardContent contentPadding={contentPadding}>{children}</CardContent>
+          {imageSrc && imagePosition === "after" && imageComponent}
         </CardContainer>
       </ThemeProvider>
     </DxcBox>
@@ -75,7 +78,6 @@ const StyledDxcCard = styled.div`
 
 const CardContainer = styled.div`
   display: inline-flex;
-  flex-direction: ${({ imagePosition }) => (imagePosition === "before" && "row") || "row-reverse"};
   height: ${(props) => props.theme.height};
   width: ${(props) => props.theme.width};
   &:hover {

--- a/lib/src/checkbox/Checkbox.tsx
+++ b/lib/src/checkbox/Checkbox.tsx
@@ -44,6 +44,19 @@ const DxcCheckbox = ({
     setIsLabelHovered(!isLabelHovered);
   };
 
+  const labelComponent = (
+    <LabelContainer
+      onClick={disabled === true ? (e) => {} : handlerCheckboxChange}
+      disabled={disabled}
+      className="labelContainer"
+      backgroundType={backgroundType}
+      onMouseOver={handleLabelHover}
+      onMouseOut={handleLabelHover}
+    >
+      {label}
+    </LabelContainer>
+  );
+
   return (
     <ThemeProvider theme={colorsTheme.checkbox}>
       <CheckboxContainer
@@ -57,6 +70,8 @@ const DxcCheckbox = ({
         backgroundType={backgroundType}
         isLabelHovered={isLabelHovered}
       >
+        {label && labelPosition === "before" && labelComponent}
+        {required && labelPosition === "before" && <DxcRequired />}
         <Checkbox
           checked={checked != undefined ? checked : innerChecked}
           inputProps={{
@@ -78,20 +93,8 @@ const DxcCheckbox = ({
           checked={checked != undefined ? checked : innerChecked}
           backgroundType={backgroundType}
         />
-        {required && <DxcRequired />}
-        {label && (
-          <LabelContainer
-            labelPosition={labelPosition}
-            onClick={disabled === true ? (e) => {} : handlerCheckboxChange}
-            disabled={disabled}
-            className="labelContainer"
-            backgroundType={backgroundType}
-            onMouseOver={handleLabelHover}
-            onMouseOut={handleLabelHover}
-          >
-            {label}
-          </LabelContainer>
-        )}
+        {required && labelPosition === "after" && <DxcRequired />}
+        {label && labelPosition === "after" && labelComponent}
       </CheckboxContainer>
     </ThemeProvider>
   );
@@ -180,7 +183,7 @@ const CheckboxContainer = styled.span`
   align-items: center;
   cursor: ${(props) => (props.disabled ? "not-allowed" : "pointer")};
   position: relative;
-  flex-direction: ${(props) => (props.labelPosition === "before" ? "row-reverse" : "row")};
+  vertical-align: top;
   .MuiCheckbox-colorSecondary {
     .MuiIconButton-label {
       & > .MuiSvgIcon-root {

--- a/lib/src/dropdown/Dropdown.tsx
+++ b/lib/src/dropdown/Dropdown.tsx
@@ -77,6 +77,12 @@ const DxcDropdown = ({
     </svg>
   );
 
+  const labelComponent = (
+    <DropdownTriggerLabel iconPosition={iconPosition} label={label}>
+      {label}
+    </DropdownTriggerLabel>
+  );
+
   return (
     <ThemeProvider theme={colorsTheme.dropdown}>
       <DXCDropdownContainer margin={margin} size={size} disabled={disabled}>
@@ -97,7 +103,8 @@ const DxcDropdown = ({
             ref={ref}
             tabIndex={tabIndex}
           >
-            <DropdownTriggerContainer iconPosition={iconPosition} caretHidden={caretHidden}>
+            <DropdownTriggerContainer caretHidden={caretHidden}>
+              {iconPosition === "after" && labelComponent}
               {icon ? (
                 <ButtonIconContainer label={label} iconPosition={iconPosition} disabled={disabled}>
                   {typeof icon === "object" ? icon : React.createElement(icon)}
@@ -105,9 +112,7 @@ const DxcDropdown = ({
               ) : (
                 iconSrc && <ButtonIcon label={label} src={iconSrc} iconPosition={iconPosition} />
               )}
-              <DropdownTriggerLabel iconPosition={iconPosition} label={label}>
-                {label}
-              </DropdownTriggerLabel>
+              {iconPosition === "before" && labelComponent}
             </DropdownTriggerContainer>
             <CaretIconContainer caretHidden={caretHidden} disabled={disabled}>
               {!caretHidden && (anchorEl === null ? <DownArrowIcon /> : <UpArrowIcon />)}
@@ -120,7 +125,6 @@ const DxcDropdown = ({
             getContentAnchorEl={null}
             anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
             transformOrigin={{ vertical: "top", horizontal: "left" }}
-            optionsIconPosition={optionsIconPosition}
             size={size}
             width={width}
             role={undefined}
@@ -140,6 +144,7 @@ const DxcDropdown = ({
                           disableRipple={true}
                           onClick={(event) => handleMenuItemClick(option)}
                         >
+                          {optionsIconPosition === "after" && <span className="optionLabel">{option.label}</span>}
                           {option.icon ? (
                             <ListIconContainer label={option.label} iconPosition={optionsIconPosition}>
                               {typeof option.icon === "object" ? option.icon : React.createElement(option.icon)}
@@ -149,7 +154,7 @@ const DxcDropdown = ({
                               <ListIcon label={option.label} src={option.iconSrc} iconPosition={optionsIconPosition} />
                             )
                           )}
-                          <span className="optionLabel">{option.label}</span>
+                          {optionsIconPosition === "before" && <span className="optionLabel">{option.label}</span>}
                         </MenuItem>
                       ))}
                     </MenuList>
@@ -239,8 +244,6 @@ const DXCMenu = styled(Popper)`
     }
     .MuiListItem-button {
       display: flex;
-      flex-direction: ${(props) => (props.optionsIconPosition === "after" && "row-reverse") || "row"};
-      justify-content: ${(props) => (props.optionsIconPosition === "after" && "flex-end") || ""};
       background-color: ${(props) => props.theme.optionBackgroundColor};
       font-family: ${(props) => props.theme.optionFontFamily};
       font-size: ${(props) => props.theme.optionFontSize};
@@ -319,7 +322,6 @@ const DropdownTriggerLabel = styled.span`
 const DropdownTriggerContainer = styled.span`
   display: flex;
   align-items: center;
-  flex-direction: ${(props) => (props.iconPosition === "after" && "row-reverse") || "row"};
   margin-left: 0px;
   margin-right: 0px;
   width: ${(props) => (props.caretHidden ? "100%" : "calc(100% - 36px)")};

--- a/lib/src/link/Link.tsx
+++ b/lib/src/link/Link.tsx
@@ -16,11 +16,11 @@ const DxcLink: Overload = ({
   text = "",
   margin,
   tabIndex = 0,
-}: (LinkTextProps | LinkIconProps)): JSX.Element => {
+}: LinkTextProps | LinkIconProps): JSX.Element => {
   const colorsTheme = useTheme();
   const linkContent = (
     <LinkText iconPosition={iconPosition}>
-      {text}
+      {iconPosition === "after" && text}
       {icon ? (
         <LinkIconContainer iconPosition={iconPosition}>
           {typeof icon === "object" ? icon : React.createElement(icon)}
@@ -28,6 +28,7 @@ const DxcLink: Overload = ({
       ) : (
         iconSrc && <LinkIcon src={iconSrc} iconPosition={iconPosition}></LinkIcon>
       )}
+      {iconPosition === "before" && text}
     </LinkText>
   );
 
@@ -149,10 +150,8 @@ const LinkText = styled.div`
   font-weight: ${(props) => props.theme.fontWeight};
   font-style: ${(props) => props.theme.fontStyle};
   font-family: ${(props) => props.theme.fontFamily};
-  display: inline-flex;
-  flex-direction: ${(props) => (props.iconPosition === "after" ? "row" : "row-reverse")};
-  justify-content: ${(props) => (props.iconPosition === "after" ? "flex-start" : "flex-end")};
-  align-items: center;
+  display: flex;
+  align-items: baseline; 
   max-width: 100%;
 `;
 
@@ -167,6 +166,7 @@ const LinkIconContainer = styled.div`
   height: ${(props) => props.theme.iconSize};
   ${(props) => `${props.iconPosition === "before" ? "margin-right" : "margin-left"}: ${props.theme.iconSpacing}`};
   overflow: hidden;
+  align-self: center;
 
   img,
   svg {

--- a/lib/src/radio/Radio.tsx
+++ b/lib/src/radio/Radio.tsx
@@ -34,6 +34,18 @@ const DxcRadio = ({
     }
   };
 
+  const labelComponent = (
+    <LabelContainer
+      checked={checked || innerChecked}
+      disabled={disabled}
+      onClick={(!disabled && handlerRadioChange) || null}
+      backgroundType={backgroundType}
+    >
+      {required && <DxcRequired />}
+      {label}
+    </LabelContainer>
+  );
+
   return (
     <ThemeProvider theme={colorsTheme.radio}>
       <RadioContainer
@@ -44,6 +56,7 @@ const DxcRadio = ({
         size={size}
         backgroundType={backgroundType}
       >
+        {labelPosition === "before" && labelComponent}
         <Radio
           checked={(checked != null && checked) || innerChecked}
           name={name}
@@ -52,16 +65,7 @@ const DxcRadio = ({
           disabled={disabled}
           disableRipple
         />
-        <LabelContainer
-          checked={checked || innerChecked}
-          labelPosition={labelPosition}
-          disabled={disabled}
-          onClick={(!disabled && handlerRadioChange) || null}
-          backgroundType={backgroundType}
-        >
-          {required && <DxcRequired />}
-          {label}
-        </LabelContainer>
+        {labelPosition === "after" && labelComponent}
       </RadioContainer>
     </ThemeProvider>
   );
@@ -89,7 +93,7 @@ const RadioContainer = styled.span`
   align-items: center;
   max-height: 42px;
   position: relative;
-  flex-direction: ${(props) => (props.labelPosition === "before" ? "row-reverse" : "row")};
+  vertical-align: top;
   margin: ${(props) => (props.margin && typeof props.margin !== "object" ? spaces[props.margin] : "0px")};
   margin-top: ${(props) =>
     props.margin && typeof props.margin === "object" && props.margin.top ? spaces[props.margin.top] : ""};

--- a/lib/src/switch/Switch.tsx
+++ b/lib/src/switch/Switch.tsx
@@ -35,6 +35,18 @@ const DxcSwitch = ({
     } else onChange?.(!checked);
   };
 
+  const labelComponent = (
+    <LabelContainer
+      labelPosition={labelPosition}
+      onClick={!disabled && handlerSwitchChange}
+      disabled={disabled}
+      backgroundType={backgroundType}
+    >
+      {required && <DxcRequired />}
+      {label}
+    </LabelContainer>
+  );
+
   return (
     <ThemeProvider theme={colorsTheme.switch}>
       <SwitchContainer
@@ -44,6 +56,7 @@ const DxcSwitch = ({
         size={size}
         backgroundType={backgroundType}
       >
+        {labelPosition === "before" && labelComponent}
         <Switch
           checked={checked ?? innerChecked}
           inputProps={{ name: name, tabIndex: tabIndex }}
@@ -52,15 +65,7 @@ const DxcSwitch = ({
           disabled={disabled}
           disableRipple
         />
-        <LabelContainer
-          labelPosition={labelPosition}
-          onClick={!disabled && handlerSwitchChange}
-          disabled={disabled}
-          backgroundType={backgroundType}
-        >
-          {required && <DxcRequired />}
-          {label}
-        </LabelContainer>
+        {labelPosition === "after" && labelComponent}
       </SwitchContainer>
     </ThemeProvider>
   );
@@ -83,8 +88,6 @@ const SwitchContainer = styled.div`
   width: ${(props) => calculateWidth(props.margin, props.size)};
   display: inline-flex;
   align-items: center;
-  flex-direction: ${(props) => (props.labelPosition === "after" ? "row" : "row-reverse")};
-  
 
   margin: ${(props) => (props.margin && typeof props.margin !== "object" ? spaces[props.margin] : "0px")};
   margin-top: ${(props) =>
@@ -211,6 +214,8 @@ const LabelContainer = styled.span`
     props.labelPosition === "after"
       ? `margin-left: ${props.theme.spaceBetweenLabelSwitch};`
       : `margin-right: ${props.theme.spaceBetweenLabelSwitch};`}
+
+  ${(props) => props.labelPosition === "before" && "order: -1"}
 `;
 
 export default DxcSwitch;

--- a/lib/src/tag/Tag.tsx
+++ b/lib/src/tag/Tag.tsx
@@ -29,6 +29,7 @@ const DxcTag = ({
   const tagContent = (
     <DxcBox size={size} shadowDepth={(isHovered && (onClick || linkHref) && 2) || 1}>
       <TagContent labelPosition={labelPosition}>
+        {labelPosition === "before" && size !== "small" && <TagLabel>{label}</TagLabel>}
         <IconContainer iconBgColor={iconBgColor}>
           {icon ? (
             <TagIconContainer>{typeof icon === "object" ? icon : React.createElement(icon)}</TagIconContainer>
@@ -36,7 +37,7 @@ const DxcTag = ({
             <TagIcon src={iconSrc}></TagIcon>
           )}
         </IconContainer>
-        {size !== "small" && <TagLabel>{label}</TagLabel>}
+        {labelPosition === "after" && size !== "small" && <TagLabel>{label}</TagLabel>}
       </TagContent>
     </DxcBox>
   );
@@ -93,7 +94,6 @@ const StyledDxcTag = styled.div`
 const TagContent = styled.div`
   display: inline-flex;
   align-items: center;
-  flex-direction: ${({ labelPosition }) => (labelPosition === "before" && "row-reverse") || "row"};
   width: 100%;
   height: ${(props) => props.theme.height};
 `;


### PR DESCRIPTION
Avoid the use of `row-reverse`. Now components are reordered internally.
Closes #680 