### PR TITLE
[Patch] Fix box shadow in disabled accordion group

### DIFF
--- a/docs/src/pages/themeBuilder/themes/AdvancedTheme.json
+++ b/docs/src/pages/themeBuilder/themes/AdvancedTheme.json
@@ -1,7 +1,6 @@
 {
   "accordion": {
     "backgroundColor": "#ffffff",
-    "disabledBackgroundColor": "transparent",
     "hoverBackgroundColor": "#f2eafa",
     "arrowColor": "#5f249f",
     "disabledArrowColor": "#999999",

--- a/docs/src/pages/themeBuilder/themes/schemas/Advanced.schema.json
+++ b/docs/src/pages/themeBuilder/themes/schemas/Advanced.schema.json
@@ -1,7 +1,6 @@
 {
   "accordion": {
     "backgroundColor": "color",
-    "disabledBackgroundColor": "color",
     "arrowColor": "color",
     "disabledArrowColor": "color",
     "hoverBackgroundColor": "color",

--- a/lib/src/accordion/Accordion.tsx
+++ b/lib/src/accordion/Accordion.tsx
@@ -114,8 +114,7 @@ const DXCAccordion = styled.div`
     min-width: 0;
     display: flex;
     left: 85px;
-    background-color: ${(props) =>
-      props.disabled ? props.theme.disabledBackgroundColor : props.theme.backgroundColor} !important;
+    background-color: ${(props) => props.theme.backgroundColor} !important;
     box-shadow: ${(props) =>
       `${props.theme.boxShadowOffsetX} ${props.theme.boxShadowOffsetY} ${props.theme.boxShadowBlur} ${props.theme.boxShadowColor}`};
     position: static;

--- a/lib/src/common/variables.js
+++ b/lib/src/common/variables.js
@@ -174,7 +174,6 @@ export const globalTokens = {
 export const componentTokens = {
   accordion: {
     backgroundColor: globalTokens.hal_white,
-    disabledBackgroundColor: globalTokens.transparent,
     hoverBackgroundColor: globalTokens.hal_purple_l_95,
     arrowColor: globalTokens.hal_purple_s_38,
     disabledArrowColor: globalTokens.hal_grey_l_60,


### PR DESCRIPTION
Removed `background-color: transparent` in disabled accordion. Also removed unnecessary `disabledBackgroundColor` accordion's token.

Now in a disabled accordion group, the box shadow is only at the bottom:

![image](https://user-images.githubusercontent.com/10975289/159252740-d1adff41-2910-4c52-a4e3-f84081f2d869.png)

Closes [781](https://github.com/dxc-technology/halstack-react/issues/781).

