### PR TITLE
Fix #777: New aria attributes for error and disabled states

### DIFF
--- a/lib/src/select/Select.tsx
+++ b/lib/src/select/Select.tsx
@@ -188,6 +188,7 @@ const DxcSelect = React.forwardRef<RefType, SelectPropsType>(
   ): JSX.Element => {
     const [selectId] = useState(`select-${uuidv4()}`);
     const selectLabelId = `label-${selectId}`;
+    const errorId = `error-${selectId}`;
     const optionsListId = `${selectId}-listbox`;
     const [innerValue, setInnerValue] = useState(multiple ? [] : "");
     const [searchValue, setSearchValue] = useState("");
@@ -471,11 +472,13 @@ const DxcSelect = React.forwardRef<RefType, SelectPropsType>(
             tabIndex={tabIndex}
             role="combobox"
             aria-controls={optionsListId}
+            aria-disabled={disabled}
             aria-expanded={isOpen}
             aria-haspopup="listbox"
             aria-labelledby={selectLabelId}
             aria-activedescendant={visualFocusIndex >= 0 ? `option-${visualFocusIndex}` : undefined}
             aria-invalid={error ? "true" : "false"}
+            aria-errormessage={error ? errorId : undefined}
             aria-required={!optional}
           >
             {multiple && selectedOption.length > 0 && (
@@ -572,7 +575,11 @@ const DxcSelect = React.forwardRef<RefType, SelectPropsType>(
               </OptionsList>
             )}
           </Select>
-          {!disabled && typeof error === "string" && <Error>{error}</Error>}
+          {!disabled && typeof error === "string" && (
+            <Error id={errorId} aria-live={error ? "assertive" : "off"}>
+              {error}
+            </Error>
+          )}
         </SelectContainer>
       </ThemeProvider>
     );

--- a/lib/src/text-input/TextInput.tsx
+++ b/lib/src/text-input/TextInput.tsx
@@ -114,7 +114,7 @@ const DxcTextInput = React.forwardRef<RefType, TextInputPropsType>(
     const backgroundType = useContext(BackgroundColorContext);
 
     const autosuggestId = `${inputId}-listBox`;
-    const errorId = `error-message-${inputId}`;
+    const errorId = `error-${inputId}`;
 
     const numberInputContext = useContext(NumberInputContext);
 
@@ -453,6 +453,7 @@ const DxcTextInput = React.forwardRef<RefType, TextInputPropsType>(
               role={isTextInputType() && hasSuggestions() ? "combobox" : "textbox"}
               aria-autocomplete={isTextInputType() && hasSuggestions() ? "list" : undefined}
               aria-controls={isTextInputType() && hasSuggestions() ? autosuggestId : undefined}
+              aria-disabled={disabled}
               aria-expanded={isTextInputType() && hasSuggestions() ? (isOpen ? "true" : "false") : undefined}
               aria-activedescendant={
                 isTextInputType() && hasSuggestions() && isOpen && visualFocusedSuggIndex !== -1
@@ -460,7 +461,7 @@ const DxcTextInput = React.forwardRef<RefType, TextInputPropsType>(
                   : undefined
               }
               aria-invalid={error ? "true" : "false"}
-              aria-describedby={error ? errorId : undefined}
+              aria-errormessage={error ? errorId : undefined}
               aria-required={optional ? "false" : "true"}
             />
             {!disabled && error && (
@@ -564,7 +565,7 @@ const DxcTextInput = React.forwardRef<RefType, TextInputPropsType>(
             )}
           </InputContainer>
           {!disabled && typeof error === "string" && (
-            <Error id={errorId} backgroundType={backgroundType}>
+            <Error id={errorId} backgroundType={backgroundType} aria-live={error ? "assertive" : "off"}>
               {error}
             </Error>
           )}

--- a/lib/src/textarea/Textarea.tsx
+++ b/lib/src/textarea/Textarea.tsx
@@ -47,7 +47,7 @@ const DxcTextarea = React.forwardRef<RefType, TextareaPropsType>(
     const backgroundType = useContext(BackgroundColorContext);
 
     const textareaRef = useRef(null);
-    const errorId = `error-message-${textareaId}`;
+    const errorId = `error-${textareaId}`;
 
     const getLengthErrorMessage = () => `Min length ${minLength}, max length ${maxLength}.`;
 
@@ -120,12 +120,13 @@ const DxcTextarea = React.forwardRef<RefType, TextareaPropsType>(
             backgroundType={backgroundType}
             ref={textareaRef}
             tabIndex={tabIndex}
+            aria-disabled={disabled}
             aria-invalid={error ? "true" : "false"}
-            aria-describedby={error ? errorId : undefined}
+            aria-errormessage={error ? errorId : undefined}
             aria-required={optional ? "false" : "true"}
           />
           {!disabled && typeof error === "string" && (
-            <Error id={errorId} backgroundType={backgroundType}>
+            <Error id={errorId} backgroundType={backgroundType} aria-live={error ? "assertive" : "off"}>
               {error}
             </Error>
           )}

--- a/lib/test/Select.test.js
+++ b/lib/test/Select.test.js
@@ -212,12 +212,15 @@ describe("Select component tests", () => {
     expect(getByText("test-select-label")).toBeTruthy();
     expect(getByText("(Optional)")).toBeTruthy();
   });
-  test("Renders with error message", () => {
-    const { getByText, getByRole } = render(<DxcSelect label="test-select-label" error="Error message." />);
+  test("Renders with error message and correct aria attributes", () => {
+    const { getByText, getByRole } = render(<DxcSelect label="Error label" error="Error message." />);
     const select = getByRole("combobox");
+    const errorMessage = getByText("Error message.");
 
-    expect(getByText("Error message.")).toBeTruthy();
+    expect(errorMessage).toBeTruthy();
+    expect(select.getAttribute("aria-errormessage")).toBe(errorMessage.id);
     expect(select.getAttribute("aria-invalid")).toBe("true");
+    expect(errorMessage.getAttribute("aria-live")).toBe("assertive");
   });
   test("Disabled select - Clear all options action must be shown but not clickable", () => {
     const { getByRole, getByText, queryByRole } = render(
@@ -225,6 +228,7 @@ describe("Select component tests", () => {
     );
     const select = getByRole("combobox");
 
+    expect(select.getAttribute("aria-disabled")).toBe("true");
     userEvent.click(select);
     expect(queryByRole("listbox")).toBeFalsy();
     userEvent.click(getByRole("button"));
@@ -929,6 +933,7 @@ describe("Select component tests", () => {
     const select = getByRole("combobox");
     const label = getByText("test-select-label");
 
+    expect(select.getAttribute("aria-disabled")).toBe("false");
     expect(select.getAttribute("aria-haspopup")).toBe("listbox");
     expect(select.getAttribute("aria-expanded")).toBe("false");
     expect(select.getAttribute("aria-required")).toBe("true");

--- a/lib/test/TextInput.test.js
+++ b/lib/test/TextInput.test.js
@@ -50,9 +50,16 @@ describe("TextInput component tests", () => {
     const input = getByRole("textbox");
     expect(input.getAttribute("placeholder")).toBe("Placeholder");
   });
-  test("Renders with error message", () => {
-    const { getByText } = render(<DxcTextInput label="Error label" placeholder="Placeholder" error="Error message." />);
-    expect(getByText("Error message.")).toBeTruthy();
+  test("Renders with error message and correct aria attributes", () => {
+    const { getByText, getByRole } = render(
+      <DxcTextInput label="Error label" placeholder="Placeholder" error="Error message." />
+    );
+    const input = getByRole("textbox");
+    const errorMessage = getByText("Error message.");
+    expect(errorMessage).toBeTruthy();
+    expect(input.getAttribute("aria-errormessage")).toBe(errorMessage.id);
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(errorMessage.getAttribute("aria-live")).toBe("assertive");
   });
   test("Not optional constraint (onBlur)", () => {
     const onChange = jest.fn();
@@ -214,6 +221,14 @@ describe("TextInput component tests", () => {
     userEvent.click(closeAction);
     expect(input.value).toBe("");
   });
+  test("Disabled input renders with correct aria and can not be modified", () => {
+    const onChange = jest.fn();
+    const { getByRole } = render(<DxcTextInput label="Input label" onChange={onChange} disabled />);
+    const input = getByRole("textbox");
+    expect(input.getAttribute("aria-disabled")).toBe("true");
+    userEvent.type(input, "Test");
+    expect(onChange).not.toHaveBeenCalled();
+  });
   test("Disabled input (action must be shown but not clickable)", () => {
     const onClick = jest.fn();
     const action = {
@@ -311,7 +326,7 @@ describe("TextInput component tests", () => {
     expect(input.getAttribute("aria-expanded")).toBeNull();
     expect(input.getAttribute("aria-activedescendant")).toBeNull();
     expect(input.getAttribute("aria-invalid")).toBe("false");
-    expect(input.getAttribute("aria-describedBy")).toBeNull();
+    expect(input.getAttribute("aria-errormessage")).toBeNull();
     expect(input.getAttribute("aria-required")).toBe("true");
     userEvent.type(input, "Text");
     const clear = getAllByRole("button")[0];

--- a/lib/test/Textarea.test.js
+++ b/lib/test/Textarea.test.js
@@ -28,12 +28,14 @@ describe("Textarea component tests", () => {
     const textarea = getByRole("textbox");
     expect(textarea.getAttribute("placeholder")).toBe("Placeholder");
   });
-  test("Renders with error message", () => {
-    const { getByText, getByRole } = render(<DxcTextarea error="Error message." />);
-    const textarea = getByRole("textbox");
-    expect(getByText("Error message.")).toBeTruthy();
+  test("Renders with error message and correct aria attributes", () => {
+    const { getByText, getByLabelText } = render(<DxcTextarea label="Example label" error="Error message." />);
+    const textarea = getByLabelText("Example label");
+    const errorMessage = getByText("Error message.");
+    expect(errorMessage).toBeTruthy();
+    expect(textarea.getAttribute("aria-errormessage")).toBe(errorMessage.id);
     expect(textarea.getAttribute("aria-invalid")).toBe("true");
-    expect(textarea.getAttribute("aria-describedBy")).not.toBeNull();
+    expect(errorMessage.getAttribute("aria-live")).toBe("assertive");
   });
   test("Renders with correct default rows", () => {
     const { getByLabelText } = render(<DxcTextarea label="Example label" rows={10} />);
@@ -43,9 +45,18 @@ describe("Textarea component tests", () => {
   test("Renders with correct accesibility attributes", () => {
     const { getByLabelText } = render(<DxcTextarea label="Example label" />);
     const textarea = getByLabelText("Example label");
+    expect(textarea.getAttribute("aria-disabled")).toBe("false");
     expect(textarea.getAttribute("aria-invalid")).toBe("false");
     expect(textarea.getAttribute("aria-describedBy")).toBeNull();
     expect(textarea.getAttribute("aria-required")).toBe("true");
+  });
+  test("Disabled textarea renders with correct aria and can not be modified", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(<DxcTextarea label="Example label" onChange={onChange} disabled />);
+    const textarea = getByLabelText("Example label");
+    expect(textarea.getAttribute("aria-disabled")).toBe("true");
+    userEvent.type(textarea, "Test");
+    expect(onChange).not.toHaveBeenCalled();
   });
   test("Not optional constraint (onBlur)", () => {
     const onChange = jest.fn();
@@ -141,7 +152,7 @@ describe("Textarea component tests", () => {
   test("Pattern and length constraints", () => {
     const onChange = jest.fn();
     const onBlur = jest.fn();
-    const { getByLabelText, getByText, queryByText } = render(
+    const { getByLabelText } = render(
       <DxcTextarea
         label="Example label"
         placeholder="Placeholder"


### PR DESCRIPTION
Fixes #777. Summary (Select, Textarea and TextInput components):

- New aria attributes `aria-disabled` for disabled state.
- New aria attributes `aria-errormessage` and `aria-live` for error state.
- Tests for checking correct aria labelling.