### PR TITLE
Fix ThemeProvider memorized theme issue

### DIFF
--- a/lib/src/ThemeContext.tsx
+++ b/lib/src/ThemeContext.tsx
@@ -114,7 +114,8 @@ const parseTheme = (theme) => {
   chipTokens.disabledFontColor = setOpacity(theme?.chip?.fontColor, 0.34) ?? chipTokens.disabledFontColor;
 
   const dateTokens = componentTokensCopy.dateInput;
-  dateTokens.pickerSelectedDateBackgroundColor = theme?.dateInput?.baseColor ?? dateTokens.pickerSelectedDateBackgroundColor;
+  dateTokens.pickerSelectedDateBackgroundColor =
+    theme?.dateInput?.baseColor ?? dateTokens.pickerSelectedDateBackgroundColor;
   dateTokens.pickerSelectedDateColor = theme?.dateInput?.accentColor ?? dateTokens.pickerSelectedDateColor;
   dateTokens.pickerHoverDateBackgroundColor =
     setOpacity(theme?.dateInput?.baseColor, 0.34) ?? dateTokens.pickerHoverDateBackgroundColor;
@@ -259,26 +260,20 @@ const parseTheme = (theme) => {
   return componentTokensCopy;
 };
 
-type ThemeProviderCommonProps = {
+type ThemeProviderPropsType = {
+  theme?: object;
+  advancedTheme?: object;
   children: React.ReactNode;
 };
-type ThemeProviderDefaultTheme = ThemeProviderCommonProps & {
-  theme: object;
-};
-type ThemeProviderAdvancedTheme = ThemeProviderCommonProps & {
-  advancedTheme: object;
-};
-type ThemeProviderPropsType = ThemeProviderDefaultTheme | ThemeProviderAdvancedTheme;
-
-const ThemeProvider = (props: ThemeProviderPropsType): JSX.Element => {
-  const parsedTheme = useMemo(() => {
-    if ("theme" in props) return parseTheme(props.theme);
-    else if ("advancedTheme" in props) return parseAdvancedTheme(props.advancedTheme);
-  }, ["theme" in props ? props.theme : props.advancedTheme]);
+const ThemeProvider = ({ theme, advancedTheme, children }: ThemeProviderPropsType): JSX.Element => {
+  const parsedTheme = useMemo(
+    () => (theme && parseTheme(theme)) || (advancedTheme && parseAdvancedTheme(advancedTheme)),
+    [theme, advancedTheme]
+  );
 
   return (
     <Halstack>
-      <ThemeContext.Provider value={parsedTheme}>{props.children}</ThemeContext.Provider>
+      <ThemeContext.Provider value={parsedTheme}>{children}</ThemeContext.Provider>
     </Halstack>
   );
 };


### PR DESCRIPTION
The theme builder was not working well due to an issue with the ThemeProvider. This was been caused by a `useMemo` hook inside the exported component, whose array of dependencies was not working as expected, due to recent changes made to reimplement the component with typescript.
Apparently, the conditional array of dependencies was not working well with [conditional props](https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase#props-one-or-the-other-but-not-both) and the dynamic change of the theme, which is the main functionality of the theme-builder.
Solution: simplifying the types of ThemeProvider and destructuring its props to include both of them inside the array of dependencies.