### PR TITLE
Fix `build:watch` script

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -38,7 +38,7 @@
     "test": "jest",
     "test:watch": "npm test -- --watch --coverage",
     "build": "babel src --extensions .js,.jsx,.ts,.tsx --out-dir ../dist --copy-files --verbose && node ../scripts/build/copy-package.js && tsc ",
-    "build:watch": "babel src --watch --out-dir ../dist --copy-files --verbose",
+    "build:watch": "babel src --watch --extensions .js,.jsx,.ts,.tsx --out-dir ../dist --copy-files --verbose",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },


### PR DESCRIPTION
Currently `build:watch` does not work as expected. New file extensions are added to make it work.