### PR TITLE
Fix footer of the new site

### DIFF
--- a/website/screens/common/pagesList.ts
+++ b/website/screens/common/pagesList.ts
@@ -71,9 +71,7 @@ export const LinksSections: LinksSectionDetails[] = [
 
 export const getNavigationLinks = (currentPath: string): NavigationLinks => {
   const links = LinksSections.flatMap((section) => section.links);
-  const currentLinkIndex = links.findIndex((link) =>
-    currentPath.startsWith(link.path)
-  );
+  const currentLinkIndex = links.findIndex((link) => currentPath === link.path);
   if (currentLinkIndex === -1) {
     return { previousLink: null, nextLink: null };
   }


### PR DESCRIPTION
The footer of the site (`DocFooter.tsx`) had problems distinguishing paths starting with the same string, like: _"components/radio-group/"_ and _"components/radio/"_. This was due to the method `startsWith` which wasn't making match with the whole pathname.