### PR TITLE
Fix no previous or next page in Specification pages

### DIFF
--- a/website/screens/common/pagesList.ts
+++ b/website/screens/common/pagesList.ts
@@ -71,7 +71,7 @@ export const LinksSections: LinksSectionDetails[] = [
 
 export const getNavigationLinks = (currentPath: string): NavigationLinks => {
   const links = LinksSections.flatMap((section) => section.links);
-  const currentLinkIndex = links.findIndex((link) => currentPath === link.path);
+  const currentLinkIndex = links.findIndex((link) => currentPath.startsWith(link.path));
   if (currentLinkIndex === -1) {
     return { previousLink: null, nextLink: null };
   }


### PR DESCRIPTION
Previous or next pages were not shown at the footer in the specification pages.
