### PR TITLE
Fix width quickNavContainer in site

### DIFF
--- a/website/screens/common/QuickNavContainer.tsx
+++ b/website/screens/common/QuickNavContainer.tsx
@@ -77,7 +77,7 @@ const Container = styled.div`
 const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
-  max-width: 800px;
+  width: 800px;
 `;
 
 const QuickNavContainer = styled.div`


### PR DESCRIPTION
Changed `max-width` to `width` of the quick nav content in order to avoid this:

![image](https://user-images.githubusercontent.com/10975289/171387948-abf00c0a-84bf-4bcd-a0ef-7567ffe0b830.png)

Now it is working fine:

![image](https://user-images.githubusercontent.com/10975289/171388007-9d6b2c8e-61d8-42ad-8dec-4e5a59493f9e.png)
