### PR TITLE
Link fixes

### DIFF
--- a/docs/src/pages/components/Components.jsx
+++ b/docs/src/pages/components/Components.jsx
@@ -31,9 +31,13 @@ const getComponentsLinks = (type) => {
           <LastLinksColumn key={`sublist-${type}-${position}`}>
             {sublist.map((path, i) => (
               <li key={path.name}>
-                <DxcLink margin={{ top: "xxsmall" }}>
-                  <Link to={`/components/${path.path}`}>{path.name}</Link>
-                </DxcLink>
+                <Link
+                  to={`/components/${path.path}`}
+                  component={DxcLink}
+                  margin={{ top: "xxsmall" }}
+                >
+                  {path.name}
+                </Link>
               </li>
             ))}
           </LastLinksColumn>
@@ -41,9 +45,13 @@ const getComponentsLinks = (type) => {
           <LinksColumn key={`sublist-${type}-${position}`}>
             {sublist.map((path, i) => (
               <li key={path.name}>
-                <DxcLink margin={{ top: "xxsmall" }}>
-                  <Link to={`/components/${path.path}`}>{path.name}</Link>
-                </DxcLink>
+                <Link
+                  to={`/components/${path.path}`}
+                  component={DxcLink}
+                  margin={{ top: "xxsmall" }}
+                >
+                  {path.name}
+                </Link>
               </li>
             ))}
           </LinksColumn>

--- a/docs/src/pages/components/cdk-components/applicationLayout/ApplicationLayout.jsx
+++ b/docs/src/pages/components/cdk-components/applicationLayout/ApplicationLayout.jsx
@@ -34,9 +34,9 @@ function ApplicationLayout() {
         <p>
           Everything between this tags will be displayed as a header, at the top
           of the screen. If you want to show a{" "}
-          <DxcLink>
-            <Link to={`/components/header`}>DxcHeader</Link>
-          </DxcLink>
+          <Link to={`/components/header`} component={DxcLink}>
+            DxcHeader
+          </Link>
           , as a shortcut, you can use it as a direct child of the
           DxcApplicationLayout without the tags. This is optional and if it is
           not specified, the DxcHeader will be shown by default.
@@ -49,9 +49,9 @@ function ApplicationLayout() {
         <p>
           Everything between the tags will be displayed as a footer, at the
           bottom of the screen. If you want to show a{" "}
-          <DxcLink>
-            <Link to={`/components/footer`}>DxcFooter</Link>
-          </DxcLink>
+          <Link to={`/components/footer`} component={DxcLink}>
+            DxcFooter
+          </Link>
           , as a shortcut, you can use it as a direct child of the
           DxcApplicationLayout without the tags. This is optional and if it is
           not specified, the DxcFooter will be shown by default.

--- a/docs/src/pages/components/cdk-components/header/Header.jsx
+++ b/docs/src/pages/components/cdk-components/header/Header.jsx
@@ -24,9 +24,9 @@ function Input() {
         <p>
           Everything between this tags will be displayed as a dropdown. If you
           want to show a{" "}
-          <DxcLink>
-            <Link to={`/components/dropdown`}>DxcDropdown</Link>
-          </DxcLink>
+          <Link to={`/components/dropdown`} component={DxcLink}>
+            DxcDropdown
+          </Link>
           , as a shortcut, you can also use it as a direct child of the
           DxcHeader without the tags, but we recommend to use it with the tags
           since some styles will be applied for a better fit in the header.

--- a/docs/src/pages/components/cdk-components/radio/Radio.jsx
+++ b/docs/src/pages/components/cdk-components/radio/Radio.jsx
@@ -21,9 +21,9 @@ function Radio() {
       ></ComponentHeader>
       <DxcAlert type="warning" margin={{ bottom: "small" }} size="fillParent">
         The component status has been changed to deprecated. Use the new{" "}
-        <DxcLink inheritColor>
-          <Link to="/components/radioGroup">Radio Group</Link>
-        </DxcLink>{" "}
+        <Link to="/components/radioGroup" component={DxcLink} inheritColor>
+          Radio Group
+        </Link>{" "}
         component instead.
       </DxcAlert>
       <Section>

--- a/lib/src/link/Link.tsx
+++ b/lib/src/link/Link.tsx
@@ -6,7 +6,7 @@ import { Margin, LinkProps, Space } from "./types";
 
 const LinkContent = React.memo(({ iconPosition, icon, children }: LinkProps): JSX.Element => {
   return (
-    <LinkText>
+    <React.Fragment>
       {iconPosition === "after" && children}
       {icon && (
         <LinkIconContainer iconPosition={iconPosition}>
@@ -14,7 +14,7 @@ const LinkContent = React.memo(({ iconPosition, icon, children }: LinkProps): JS
         </LinkIconContainer>
       )}
       {iconPosition === "before" && children}
-    </LinkText>
+    </React.Fragment>
   );
 });
 
@@ -82,6 +82,7 @@ const StyledLink = styled.div<StyledLinkProps>`
   font-style: ${(props) => props.theme.fontStyle};
   font-family: ${(props) => props.theme.fontFamily};
   text-decoration-color: transparent;
+  width: fit-content;
 
   ${(props) =>
     `padding-bottom: ${props.theme.underlineSpacing};
@@ -115,12 +116,6 @@ const StyledLink = styled.div<StyledLinkProps>`
       `color: ${props.theme.activeFontColor} !important;
        border-bottom-color: ${props.theme.activeUnderlineColor} !important;`}
   }
-`;
-
-const LinkText = styled.div`
-  display: flex;
-  align-items: baseline;
-  max-width: 100%;
 `;
 
 const LinkIcon = styled.img``;


### PR DESCRIPTION
### Changes
- Fixed max width.
- Use of `React.Fragment` instead of a `div`.
- All Router Links changed in `docs` to be used correctly with DxcLink.