### PR TITLE
[Major] Select listbox now uses Radix UI popover

### DIFF
--- a/lib/src/select/Listbox.tsx
+++ b/lib/src/select/Listbox.tsx
@@ -22,11 +22,13 @@ const Listbox = React.forwardRef<ListboxRefType, ListboxProps>(
       optionalItem,
       searchable,
       handleOptionOnClick,
+      styles,
     },
     ref
   ): JSX.Element => {
     const colorsTheme = useTheme();
     const translatedLabels = useTranslatedLabels();
+
     let globalIndex = optional && !multiple ? 0 : -1; // index for options, starting from 0 to options.length -1
     const mapOptionFunc = (option, mapIndex) => {
       if (option.options) {
@@ -91,6 +93,7 @@ const Listbox = React.forwardRef<ListboxRefType, ListboxProps>(
           role="listbox"
           aria-multiselectable={multiple}
           aria-orientation="vertical"
+          style={styles}
         >
           {searchable && (options.length === 0 || !groupsHaveOptions(options)) ? (
             <OptionsSystemMessage>
@@ -121,15 +124,10 @@ const Listbox = React.forwardRef<ListboxRefType, ListboxProps>(
 );
 
 const ListboxContainer = styled.ul`
-  position: absolute;
-  z-index: 1;
   max-height: 304px;
   overflow-y: auto;
-  top: calc(100% + 4px);
-  left: 0;
   margin: 0;
   padding: 0.25rem 0;
-  width: 100%;
   background-color: ${(props) => props.theme.listDialogBackgroundColor};
   border: 1px solid ${(props) => props.theme.listDialogBorderColor};
   border-radius: 0.25rem;

--- a/lib/src/select/Select.test.js
+++ b/lib/src/select/Select.test.js
@@ -3,6 +3,21 @@ import DxcSelect from "./Select";
 import { render, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+// Mocking DOMRect for Radix Primitive Popover
+global.ResizeObserver = class ResizeObserver {
+  constructor(cb) {
+    this.cb = cb;
+  }
+  observe() {
+    this.cb([{ borderBoxSize: { inlineSize: 0, blockSize: 0 } }]);
+  }
+  unobserve() {}
+};
+
+global.DOMRect = {
+  fromRect: () => ({ top: 0, left: 0, bottom: 0, right: 0, width: 0, height: 0 }),
+};
+
 const single_options = [
   { label: "Option 01", value: "1" },
   { label: "Option 02", value: "2" },

--- a/lib/src/select/types.ts
+++ b/lib/src/select/types.ts
@@ -193,6 +193,7 @@ export type ListboxProps = {
   optionalItem: Option;
   searchable: boolean;
   handleOptionOnClick: (option: Option) => void;
+  styles: { width: number };
 };
 
 /**


### PR DESCRIPTION
Select component is now supported by Radix UI Primitive: [Popover](https://www.radix-ui.com/docs/primitives/components/popover). This has some major improvements:

1. **The component now has collision detection.** This changes the listbox position based on the current scroll and select positioning to help the user with an always visible listbox.

https://user-images.githubusercontent.com/44321109/174848668-947588e7-96e0-4d1e-9d1e-607fb85fbf47.mp4

2. **Fixes z-index issues with material components.** The listbox now appears within a Portal with absolute positioning, so it won't be stucked behind other components such us Dialog, Button, Checkbox or anyone with a high z-index value.

https://user-images.githubusercontent.com/44321109/174847761-908ec900-34b9-43d5-9b62-991811490ad6.mp4

 