### PR TITLE
Fixed quick nav container width

### DIFF
--- a/website/screens/common/HeaderCell.tsx
+++ b/website/screens/common/HeaderCell.tsx
@@ -1,7 +1,0 @@
-import styled from "styled-components";
-
-const HeaderCell = styled.th`
-  min-width: 300px;
-`;
-
-export default HeaderCell;

--- a/website/screens/common/HeaderCell.tsx
+++ b/website/screens/common/HeaderCell.tsx
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+const HeaderCell = styled.th`
+  min-width: 300px;
+`;
+
+export default HeaderCell;

--- a/website/screens/common/HeaderDescriptionCell.tsx
+++ b/website/screens/common/HeaderDescriptionCell.tsx
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+const HeaderDescriptionCell = styled.th`
+  min-width: 300px;
+`;
+
+export default HeaderDescriptionCell;

--- a/website/screens/common/QuickNavContainer.tsx
+++ b/website/screens/common/QuickNavContainer.tsx
@@ -77,7 +77,8 @@ const Container = styled.div`
 const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 800px;
+  width: 100%;
+  max-width: 800px;
 `;
 
 const QuickNavContainer = styled.div`

--- a/website/screens/components/accordion/code/AccordionCodePage.tsx
+++ b/website/screens/components/accordion/code/AccordionCodePage.tsx
@@ -9,6 +9,7 @@ import uncontrolledAccordion from "./examples/uncontrolledAccordion";
 import icons from "./examples/icons";
 import controlledAccordionGroup from "./examples/controlledAccordionGroup";
 import uncontrolledAccordionGroup from "./examples/uncontrolledAccordionGroup";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -21,7 +22,7 @@ const sections = [
             <tr>
               <th>Name</th>
               <th>Default</th>
-              <th>Description</th>
+              <HeaderCell>Description</HeaderCell>
             </tr>
             <tr>
               <td>label: string</td>
@@ -117,7 +118,7 @@ const sections = [
             <tr>
               <th>Name</th>
               <th>Default</th>
-              <th>Description</th>
+              <HeaderCell>Description</HeaderCell>
             </tr>
             <tr>
               <td>defaultIndexActive: number</td>
@@ -179,7 +180,7 @@ const sections = [
                     <tr>
                       <th>Name</th>
                       <th>Default</th>
-                      <th>Description</th>
+                      <HeaderCell>Description</HeaderCell>
                     </tr>
                     <tr>
                       <td>label: string</td>

--- a/website/screens/components/accordion/code/AccordionCodePage.tsx
+++ b/website/screens/components/accordion/code/AccordionCodePage.tsx
@@ -9,7 +9,7 @@ import uncontrolledAccordion from "./examples/uncontrolledAccordion";
 import icons from "./examples/icons";
 import controlledAccordionGroup from "./examples/controlledAccordionGroup";
 import uncontrolledAccordionGroup from "./examples/uncontrolledAccordionGroup";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -22,7 +22,7 @@ const sections = [
             <tr>
               <th>Name</th>
               <th>Default</th>
-              <HeaderCell>Description</HeaderCell>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
             </tr>
             <tr>
               <td>label: string</td>
@@ -118,7 +118,7 @@ const sections = [
             <tr>
               <th>Name</th>
               <th>Default</th>
-              <HeaderCell>Description</HeaderCell>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
             </tr>
             <tr>
               <td>defaultIndexActive: number</td>
@@ -180,7 +180,7 @@ const sections = [
                     <tr>
                       <th>Name</th>
                       <th>Default</th>
-                      <HeaderCell>Description</HeaderCell>
+                      <HeaderDescriptionCell>Description</HeaderDescriptionCell>
                     </tr>
                     <tr>
                       <td>label: string</td>

--- a/website/screens/components/alert/code/AlertCodePage.tsx
+++ b/website/screens/components/alert/code/AlertCodePage.tsx
@@ -6,6 +6,7 @@ import basicUsage from "./examples/basicUsage";
 import modal from "./examples/modal";
 import Example from "@/common/example/Example";
 import Code from "@/common/Code";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>type: 'info' | 'confirm' | 'warning' | 'error'</td>

--- a/website/screens/components/alert/usage/AlertUsagePage.tsx
+++ b/website/screens/components/alert/usage/AlertUsagePage.tsx
@@ -10,6 +10,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import types from "../usage/examples/types";
 import content from "./examples/content";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -53,7 +54,7 @@ const sections = [
           <thead>
             <tr>
               <th>Name</th>
-              <th>Description</th>
+              <HeaderCell>Description</HeaderCell>
             </tr>
           </thead>
           <tbody>
@@ -106,7 +107,7 @@ const sections = [
         <thead>
           <tr>
             <th>Name</th>
-            <th>Description</th>
+            <HeaderCell>Description</HeaderCell>
           </tr>
         </thead>
         <tbody>

--- a/website/screens/components/alert/usage/AlertUsagePage.tsx
+++ b/website/screens/components/alert/usage/AlertUsagePage.tsx
@@ -10,7 +10,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import types from "../usage/examples/types";
 import content from "./examples/content";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -54,7 +54,7 @@ const sections = [
           <thead>
             <tr>
               <th>Name</th>
-              <HeaderCell>Description</HeaderCell>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
             </tr>
           </thead>
           <tbody>
@@ -107,7 +107,7 @@ const sections = [
         <thead>
           <tr>
             <th>Name</th>
-            <HeaderCell>Description</HeaderCell>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
           </tr>
         </thead>
         <tbody>

--- a/website/screens/components/application-layout/code/ApplicationLayoutCodePage.tsx
+++ b/website/screens/components/application-layout/code/ApplicationLayoutCodePage.tsx
@@ -12,13 +12,14 @@ import Link from "next/link";
 import basicUsage from "./examples/basicUsage";
 import withSidenav from "./examples/withSideNav";
 import customHeaderFooter from "./examples/customHeaderFooter";
+import HeaderCell from "@/common/HeaderCell";
 
 const ApplicationLayoutPropsTable = () => (
   <DxcTable>
     <tr>
       <th>Name</th>
       <th>Default</th>
-      <th>Description</th>
+      <HeaderCell>Description</HeaderCell>
     </tr>
     <tr>
       <td>visibilityToggleLabel: string</td>
@@ -36,7 +37,7 @@ const SidenavApplicationLayoutPropsTable = () => (
     <tr>
       <th>Name</th>
       <th>Default</th>
-      <th>Description</th>
+      <HeaderCell>Description</HeaderCell>
     </tr>
     <tr>
       <td>padding: string | object</td>

--- a/website/screens/components/application-layout/code/ApplicationLayoutCodePage.tsx
+++ b/website/screens/components/application-layout/code/ApplicationLayoutCodePage.tsx
@@ -12,14 +12,14 @@ import Link from "next/link";
 import basicUsage from "./examples/basicUsage";
 import withSidenav from "./examples/withSideNav";
 import customHeaderFooter from "./examples/customHeaderFooter";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const ApplicationLayoutPropsTable = () => (
   <DxcTable>
     <tr>
       <th>Name</th>
       <th>Default</th>
-      <HeaderCell>Description</HeaderCell>
+      <HeaderDescriptionCell>Description</HeaderDescriptionCell>
     </tr>
     <tr>
       <td>visibilityToggleLabel: string</td>
@@ -37,7 +37,7 @@ const SidenavApplicationLayoutPropsTable = () => (
     <tr>
       <th>Name</th>
       <th>Default</th>
-      <HeaderCell>Description</HeaderCell>
+      <HeaderDescriptionCell>Description</HeaderDescriptionCell>
     </tr>
     <tr>
       <td>padding: string | object</td>

--- a/website/screens/components/box/code/BoxCodePage.tsx
+++ b/website/screens/components/box/code/BoxCodePage.tsx
@@ -5,7 +5,7 @@ import Code from "@/common/Code";
 import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -16,7 +16,7 @@ const sections = [
           <tr>
             <th>Name</th>
             <th>Default</th>
-            <HeaderCell>Description</HeaderCell>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
           </tr>
         </thead>
         <tbody>

--- a/website/screens/components/box/code/BoxCodePage.tsx
+++ b/website/screens/components/box/code/BoxCodePage.tsx
@@ -5,6 +5,7 @@ import Code from "@/common/Code";
 import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
           <tr>
             <th>Name</th>
             <th>Default</th>
-            <th>Description</th>
+            <HeaderCell>Description</HeaderCell>
           </tr>
         </thead>
         <tbody>

--- a/website/screens/components/button/code/ButtonCodePage.tsx
+++ b/website/screens/components/button/code/ButtonCodePage.tsx
@@ -6,7 +6,7 @@ import QuickNavContainerLayout from "@/common/QuickNavContainerLayout";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import icons from "./examples/icons";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -16,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>mode: 'primary' | 'secondary' | 'text'</td>

--- a/website/screens/components/button/code/ButtonCodePage.tsx
+++ b/website/screens/components/button/code/ButtonCodePage.tsx
@@ -6,6 +6,7 @@ import QuickNavContainerLayout from "@/common/QuickNavContainerLayout";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import icons from "./examples/icons";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>mode: 'primary' | 'secondary' | 'text'</td>

--- a/website/screens/components/button/usage/ButtonUsagePage.tsx
+++ b/website/screens/components/button/usage/ButtonUsagePage.tsx
@@ -10,7 +10,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import variants from "./examples/variants";
 import icons from "./examples/iconUsage";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -52,7 +52,7 @@ const sections = [
           <thead>
             <tr>
               <th>Variant</th>
-              <HeaderCell>Description</HeaderCell>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/button/usage/ButtonUsagePage.tsx
+++ b/website/screens/components/button/usage/ButtonUsagePage.tsx
@@ -10,6 +10,8 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import variants from "./examples/variants";
 import icons from "./examples/iconUsage";
+import HeaderCell from "@/common/HeaderCell";
+
 const sections = [
   {
     title: "Usage",
@@ -50,7 +52,7 @@ const sections = [
           <thead>
             <tr>
               <th>Variant</th>
-              <th>Description</th>
+              <HeaderCell>Description</HeaderCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/card/code/CardCodePage.tsx
+++ b/website/screens/components/card/code/CardCodePage.tsx
@@ -10,6 +10,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import Code from "@/common/Code";
 import basicUsage from "./examples/basicUsage";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -21,7 +22,7 @@ const sections = [
             <tr>
               <th>Name</th>
               <th>Default</th>
-              <th>Description</th>
+              <HeaderCell>Description</HeaderCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/card/code/CardCodePage.tsx
+++ b/website/screens/components/card/code/CardCodePage.tsx
@@ -10,7 +10,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import Code from "@/common/Code";
 import basicUsage from "./examples/basicUsage";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -22,7 +22,7 @@ const sections = [
             <tr>
               <th>Name</th>
               <th>Default</th>
-              <HeaderCell>Description</HeaderCell>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/checkbox/code/CheckboxCodePage.tsx
+++ b/website/screens/components/checkbox/code/CheckboxCodePage.tsx
@@ -6,7 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -16,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>defaultChecked: boolean</td>

--- a/website/screens/components/checkbox/code/CheckboxCodePage.tsx
+++ b/website/screens/components/checkbox/code/CheckboxCodePage.tsx
@@ -6,6 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>defaultChecked: boolean</td>

--- a/website/screens/components/chip/code/ChipCodePage.tsx
+++ b/website/screens/components/chip/code/ChipCodePage.tsx
@@ -6,7 +6,7 @@ import Example from "@/common/example/Example";
 import Code from "@/common/Code";
 import basicUsage from "./examples/basicUsage";
 import icons from "./examples/icons";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -16,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>label: string</td>

--- a/website/screens/components/chip/code/ChipCodePage.tsx
+++ b/website/screens/components/chip/code/ChipCodePage.tsx
@@ -6,6 +6,7 @@ import Example from "@/common/example/Example";
 import Code from "@/common/Code";
 import basicUsage from "./examples/basicUsage";
 import icons from "./examples/icons";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>label: string</td>

--- a/website/screens/components/date-input/code/DateInputCodePage.tsx
+++ b/website/screens/components/date-input/code/DateInputCodePage.tsx
@@ -8,6 +8,7 @@ import basicUsage from "./examples/basicUsage";
 import errorHandling from "./examples/errorHandling";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -18,7 +19,7 @@ const sections = [
           <tr>
             <th>Name</th>
             <th>Default</th>
-            <th>Description</th>
+            <HeaderCell>Description</HeaderCell>
           </tr>
         </thead>
         <tbody>

--- a/website/screens/components/date-input/code/DateInputCodePage.tsx
+++ b/website/screens/components/date-input/code/DateInputCodePage.tsx
@@ -8,7 +8,7 @@ import basicUsage from "./examples/basicUsage";
 import errorHandling from "./examples/errorHandling";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -19,7 +19,7 @@ const sections = [
           <tr>
             <th>Name</th>
             <th>Default</th>
-            <HeaderCell>Description</HeaderCell>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
           </tr>
         </thead>
         <tbody>

--- a/website/screens/components/dialog/code/DialogCodePage.tsx
+++ b/website/screens/components/dialog/code/DialogCodePage.tsx
@@ -7,6 +7,7 @@ import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import withContent from "./examples/withContent";
 import backgroundClick from "./examples/backgroundClick";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -16,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>isCloseVisible: boolean</td>

--- a/website/screens/components/dialog/code/DialogCodePage.tsx
+++ b/website/screens/components/dialog/code/DialogCodePage.tsx
@@ -7,7 +7,7 @@ import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import withContent from "./examples/withContent";
 import backgroundClick from "./examples/backgroundClick";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -17,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>isCloseVisible: boolean</td>

--- a/website/screens/components/dropdown/code/DropdownCodePage.tsx
+++ b/website/screens/components/dropdown/code/DropdownCodePage.tsx
@@ -6,7 +6,7 @@ import Code from "@/common/Code";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import icons from "./examples/icons";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -17,7 +17,7 @@ const sections = [
           <tr>
             <th>Name</th>
             <th>Default</th>
-            <HeaderCell>Description</HeaderCell>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
           </tr>
           <tr>
             <td>options: object[]</td>

--- a/website/screens/components/dropdown/code/DropdownCodePage.tsx
+++ b/website/screens/components/dropdown/code/DropdownCodePage.tsx
@@ -6,6 +6,7 @@ import Code from "@/common/Code";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import icons from "./examples/icons";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -16,7 +17,7 @@ const sections = [
           <tr>
             <th>Name</th>
             <th>Default</th>
-            <th>Description</th>
+            <HeaderCell>Description</HeaderCell>
           </tr>
           <tr>
             <td>options: object[]</td>

--- a/website/screens/components/file-input/code/FileInputCodePage.tsx
+++ b/website/screens/components/file-input/code/FileInputCodePage.tsx
@@ -6,7 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import errorHandling from "./examples/errorHandling";
 import basicUsage from "./examples/basicUsage";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -16,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>name: string</td>

--- a/website/screens/components/file-input/code/FileInputCodePage.tsx
+++ b/website/screens/components/file-input/code/FileInputCodePage.tsx
@@ -6,6 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import errorHandling from "./examples/errorHandling";
 import basicUsage from "./examples/basicUsage";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>name: string</td>

--- a/website/screens/components/footer/code/FooterCodePage.tsx
+++ b/website/screens/components/footer/code/FooterCodePage.tsx
@@ -6,7 +6,7 @@ import Code from "@/common/Code";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import socialLinks from "./examples/socialLinks";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -16,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>socialLinks: object[]</td>

--- a/website/screens/components/footer/code/FooterCodePage.tsx
+++ b/website/screens/components/footer/code/FooterCodePage.tsx
@@ -6,6 +6,7 @@ import Code from "@/common/Code";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import socialLinks from "./examples/socialLinks";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>socialLinks: object[]</td>

--- a/website/screens/components/header/code/HeaderCodePage.tsx
+++ b/website/screens/components/header/code/HeaderCodePage.tsx
@@ -14,7 +14,7 @@ import customContent from "./examples/customContent";
 import dropdown from "./examples/dropdown";
 import Link from "next/link";
 import React from "react";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -24,7 +24,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>underlined: boolean</td>

--- a/website/screens/components/header/code/HeaderCodePage.tsx
+++ b/website/screens/components/header/code/HeaderCodePage.tsx
@@ -14,6 +14,7 @@ import customContent from "./examples/customContent";
 import dropdown from "./examples/dropdown";
 import Link from "next/link";
 import React from "react";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -23,7 +24,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>underlined: boolean</td>

--- a/website/screens/components/heading/code/HeadingCodePage.tsx
+++ b/website/screens/components/heading/code/HeadingCodePage.tsx
@@ -5,7 +5,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import Code from "@/common/Code";
 import basicUsage from "./examples/basicUsage";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -16,7 +16,7 @@ const sections = [
           <tr>
             <th>Name</th>
             <th>Default</th>
-            <HeaderCell>Description</HeaderCell>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
           </tr>
           <tr>
             <td>level: number</td>

--- a/website/screens/components/heading/code/HeadingCodePage.tsx
+++ b/website/screens/components/heading/code/HeadingCodePage.tsx
@@ -5,6 +5,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import Code from "@/common/Code";
 import basicUsage from "./examples/basicUsage";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
           <tr>
             <th>Name</th>
             <th>Default</th>
-            <th>Description</th>
+            <HeaderCell>Description</HeaderCell>
           </tr>
           <tr>
             <td>level: number</td>

--- a/website/screens/components/link/code/LinkCodePage.tsx
+++ b/website/screens/components/link/code/LinkCodePage.tsx
@@ -14,6 +14,7 @@ import basicUsage from "./examples/basicUsage";
 import routerLink from "./examples/routerLink";
 import routerLink6 from "./examples/routerLink6";
 import icons from "./examples/icons";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -24,7 +25,7 @@ const sections = [
           <tr>
             <th>Name</th>
             <th>Default</th>
-            <th>Description</th>
+            <HeaderCell>Description</HeaderCell>
           </tr>
         </thead>
         <tbody>

--- a/website/screens/components/link/code/LinkCodePage.tsx
+++ b/website/screens/components/link/code/LinkCodePage.tsx
@@ -14,7 +14,7 @@ import basicUsage from "./examples/basicUsage";
 import routerLink from "./examples/routerLink";
 import routerLink6 from "./examples/routerLink6";
 import icons from "./examples/icons";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -25,7 +25,7 @@ const sections = [
           <tr>
             <th>Name</th>
             <th>Default</th>
-            <HeaderCell>Description</HeaderCell>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
           </tr>
         </thead>
         <tbody>

--- a/website/screens/components/nav-tabs/code/NavTabsCodePage.tsx
+++ b/website/screens/components/nav-tabs/code/NavTabsCodePage.tsx
@@ -13,7 +13,7 @@ import basicUsage from "./examples/basicUsage";
 import routerLink from "./examples/routerLink";
 import routerLinkV6 from "./examples/routerLinkV6";
 import nextLink from "./examples/nextLink";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -26,7 +26,7 @@ const sections = [
             <tr>
               <th>Name</th>
               <th>Default</th>
-              <HeaderCell>Description</HeaderCell>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
             </tr>
             <tr>
               <td>iconPosition: 'top' | 'left'</td>
@@ -55,7 +55,7 @@ const sections = [
             <tr>
               <th>Name</th>
               <th>Default</th>
-              <HeaderCell>Description</HeaderCell>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
             </tr>
             <tr>
               <td>active: boolean</td>

--- a/website/screens/components/nav-tabs/code/NavTabsCodePage.tsx
+++ b/website/screens/components/nav-tabs/code/NavTabsCodePage.tsx
@@ -13,6 +13,7 @@ import basicUsage from "./examples/basicUsage";
 import routerLink from "./examples/routerLink";
 import routerLinkV6 from "./examples/routerLinkV6";
 import nextLink from "./examples/nextLink";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -25,7 +26,7 @@ const sections = [
             <tr>
               <th>Name</th>
               <th>Default</th>
-              <th>Description</th>
+              <HeaderCell>Description</HeaderCell>
             </tr>
             <tr>
               <td>iconPosition: 'top' | 'left'</td>
@@ -54,7 +55,7 @@ const sections = [
             <tr>
               <th>Name</th>
               <th>Default</th>
-              <th>Description</th>
+              <HeaderCell>Description</HeaderCell>
             </tr>
             <tr>
               <td>active: boolean</td>

--- a/website/screens/components/number-input/code/NumberInputCodePage.tsx
+++ b/website/screens/components/number-input/code/NumberInputCodePage.tsx
@@ -7,7 +7,7 @@ import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import errorUsage from "./examples/errorHandling";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -17,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>defaultValue: string</td>

--- a/website/screens/components/number-input/code/NumberInputCodePage.tsx
+++ b/website/screens/components/number-input/code/NumberInputCodePage.tsx
@@ -7,6 +7,7 @@ import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import errorUsage from "./examples/errorHandling";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -16,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>defaultValue: string</td>

--- a/website/screens/components/paginator/code/PaginatorCodePage.tsx
+++ b/website/screens/components/paginator/code/PaginatorCodePage.tsx
@@ -5,6 +5,7 @@ import QuickNavContainer from "@/common/QuickNavContainer";
 import QuickNavContainerLayout from "@/common/QuickNavContainerLayout";
 import { DxcStack, DxcTable, DxcText } from "@dxc-technology/halstack-react";
 import itemsPerPage from "./examples/itemsPerPage";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -14,7 +15,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>currentPage: number</td>

--- a/website/screens/components/paginator/code/PaginatorCodePage.tsx
+++ b/website/screens/components/paginator/code/PaginatorCodePage.tsx
@@ -5,7 +5,7 @@ import QuickNavContainer from "@/common/QuickNavContainer";
 import QuickNavContainerLayout from "@/common/QuickNavContainerLayout";
 import { DxcStack, DxcTable, DxcText } from "@dxc-technology/halstack-react";
 import itemsPerPage from "./examples/itemsPerPage";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -15,7 +15,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>currentPage: number</td>

--- a/website/screens/components/password-input/code/PasswordInputCodePage.tsx
+++ b/website/screens/components/password-input/code/PasswordInputCodePage.tsx
@@ -7,6 +7,7 @@ import { DxcStack, DxcTable } from "@dxc-technology/halstack-react";
 import controlled from "./examples/controlled";
 import errorHandling from "./examples/errorHandling";
 import uncontrolled from "./examples/uncontrolled";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -16,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>value: string</td>

--- a/website/screens/components/password-input/code/PasswordInputCodePage.tsx
+++ b/website/screens/components/password-input/code/PasswordInputCodePage.tsx
@@ -7,7 +7,7 @@ import { DxcStack, DxcTable } from "@dxc-technology/halstack-react";
 import controlled from "./examples/controlled";
 import errorHandling from "./examples/errorHandling";
 import uncontrolled from "./examples/uncontrolled";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -17,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>value: string</td>

--- a/website/screens/components/progress-bar/code/ProgressBarCodePage.tsx
+++ b/website/screens/components/progress-bar/code/ProgressBarCodePage.tsx
@@ -6,7 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basic from "./examples/basicUsage";
 import overlay from "./examples/overlay";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -16,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>label: string</td>

--- a/website/screens/components/progress-bar/code/ProgressBarCodePage.tsx
+++ b/website/screens/components/progress-bar/code/ProgressBarCodePage.tsx
@@ -6,6 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basic from "./examples/basicUsage";
 import overlay from "./examples/overlay";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>label: string</td>

--- a/website/screens/components/quick-nav/code/QuickNavCodePage.tsx
+++ b/website/screens/components/quick-nav/code/QuickNavCodePage.tsx
@@ -5,6 +5,7 @@ import DocFooter from "@/common/DocFooter";
 import Code from "@/common/Code";
 import Example from "@/common/example/Example";
 import quickNav from "./examples/quickNav";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -14,7 +15,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>title: string</td>

--- a/website/screens/components/quick-nav/code/QuickNavCodePage.tsx
+++ b/website/screens/components/quick-nav/code/QuickNavCodePage.tsx
@@ -5,7 +5,7 @@ import DocFooter from "@/common/DocFooter";
 import Code from "@/common/Code";
 import Example from "@/common/example/Example";
 import quickNav from "./examples/quickNav";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -15,7 +15,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>title: string</td>

--- a/website/screens/components/radio-group/code/RadioGroupCodePage.tsx
+++ b/website/screens/components/radio-group/code/RadioGroupCodePage.tsx
@@ -7,7 +7,7 @@ import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import errorHandling from "./examples/errorHandling";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -17,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>defaultValue: string</td>

--- a/website/screens/components/radio-group/code/RadioGroupCodePage.tsx
+++ b/website/screens/components/radio-group/code/RadioGroupCodePage.tsx
@@ -7,6 +7,7 @@ import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import errorHandling from "./examples/errorHandling";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -16,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>defaultValue: string</td>

--- a/website/screens/components/radio-group/usage/RadioGroupUsagePage.tsx
+++ b/website/screens/components/radio-group/usage/RadioGroupUsagePage.tsx
@@ -9,6 +9,7 @@ import QuickNavContainerLayout from "@/common/QuickNavContainerLayout";
 import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import stacking from "./examples/stacking";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -40,7 +41,7 @@ const sections = [
           <thead>
             <tr>
               <th>Name</th>
-              <th>Description</th>
+              <HeaderCell>Description</HeaderCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/radio-group/usage/RadioGroupUsagePage.tsx
+++ b/website/screens/components/radio-group/usage/RadioGroupUsagePage.tsx
@@ -9,7 +9,7 @@ import QuickNavContainerLayout from "@/common/QuickNavContainerLayout";
 import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import stacking from "./examples/stacking";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -41,7 +41,7 @@ const sections = [
           <thead>
             <tr>
               <th>Name</th>
-              <HeaderCell>Description</HeaderCell>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/resultset-table/code/ResultsetTableCodePage.tsx
+++ b/website/screens/components/resultset-table/code/ResultsetTableCodePage.tsx
@@ -6,7 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import sortable from "./examples/sortable";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -16,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>columns: object[]</td>

--- a/website/screens/components/resultset-table/code/ResultsetTableCodePage.tsx
+++ b/website/screens/components/resultset-table/code/ResultsetTableCodePage.tsx
@@ -6,6 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import sortable from "./examples/sortable";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>columns: object[]</td>

--- a/website/screens/components/select/code/SelectCodePage.tsx
+++ b/website/screens/components/select/code/SelectCodePage.tsx
@@ -9,7 +9,7 @@ import uncontrolled from "./examples/uncontrolled";
 import errorHandling from "./examples/errorHandling";
 import groups from "./examples/groupedOptions";
 import icons from "./examples/icons";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -20,7 +20,7 @@ const sections = [
           <tr>
             <th>Name</th>
             <th>Default</th>
-            <HeaderCell>Description</HeaderCell>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
           </tr>
         </thead>
         <tbody>

--- a/website/screens/components/select/code/SelectCodePage.tsx
+++ b/website/screens/components/select/code/SelectCodePage.tsx
@@ -9,6 +9,7 @@ import uncontrolled from "./examples/uncontrolled";
 import errorHandling from "./examples/errorHandling";
 import groups from "./examples/groupedOptions";
 import icons from "./examples/icons";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -19,7 +20,7 @@ const sections = [
           <tr>
             <th>Name</th>
             <th>Default</th>
-            <th>Description</th>
+            <HeaderCell>Description</HeaderCell>
           </tr>
         </thead>
         <tbody>

--- a/website/screens/components/select/usage/SelectUsagePage.tsx
+++ b/website/screens/components/select/usage/SelectUsagePage.tsx
@@ -11,7 +11,7 @@ import Example from "@/common/example/Example";
 import variants from "./examples/variants";
 import requiredOptional from "./examples/requiredOptional";
 import filterable from "./examples/filterable";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -52,7 +52,7 @@ const sections = [
           <thead>
             <tr>
               <th>Variant</th>
-              <HeaderCell>Description</HeaderCell>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/select/usage/SelectUsagePage.tsx
+++ b/website/screens/components/select/usage/SelectUsagePage.tsx
@@ -11,6 +11,7 @@ import Example from "@/common/example/Example";
 import variants from "./examples/variants";
 import requiredOptional from "./examples/requiredOptional";
 import filterable from "./examples/filterable";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -51,7 +52,7 @@ const sections = [
           <thead>
             <tr>
               <th>Variant</th>
-              <th>Description</th>
+              <HeaderCell>Description</HeaderCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/sidenav/usage/SidenavUsagePage.tsx
+++ b/website/screens/components/sidenav/usage/SidenavUsagePage.tsx
@@ -12,7 +12,7 @@ import DocFooter from "@/common/DocFooter";
 import Code from "@/common/Code";
 import sidenavVariants from "./images/sidenav_variants.png";
 import sidenavResponsive from "./images/sidenav_responsive.png";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -61,7 +61,7 @@ const sections = [
           <thead>
             <tr>
               <th>Variant</th>
-              <HeaderCell>Description</HeaderCell>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/sidenav/usage/SidenavUsagePage.tsx
+++ b/website/screens/components/sidenav/usage/SidenavUsagePage.tsx
@@ -12,6 +12,7 @@ import DocFooter from "@/common/DocFooter";
 import Code from "@/common/Code";
 import sidenavVariants from "./images/sidenav_variants.png";
 import sidenavResponsive from "./images/sidenav_responsive.png";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -60,7 +61,7 @@ const sections = [
           <thead>
             <tr>
               <th>Variant</th>
-              <th>Description</th>
+              <HeaderCell>Description</HeaderCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/slider/code/SliderCodePage.tsx
+++ b/website/screens/components/slider/code/SliderCodePage.tsx
@@ -7,6 +7,7 @@ import Code from "@/common/Code";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import formatLabel from "./examples/formatLabel";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -16,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>defaultValue: number</td>

--- a/website/screens/components/slider/code/SliderCodePage.tsx
+++ b/website/screens/components/slider/code/SliderCodePage.tsx
@@ -7,7 +7,7 @@ import Code from "@/common/Code";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import formatLabel from "./examples/formatLabel";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -17,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>defaultValue: number</td>

--- a/website/screens/components/slider/usage/SliderUsagePage.tsx
+++ b/website/screens/components/slider/usage/SliderUsagePage.tsx
@@ -10,7 +10,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import variants from "./examples/variants";
 import input from "./examples/input";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -41,7 +41,7 @@ const sections = [
           <thead>
             <tr>
               <th>Variant</th>
-              <HeaderCell>Description</HeaderCell>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/slider/usage/SliderUsagePage.tsx
+++ b/website/screens/components/slider/usage/SliderUsagePage.tsx
@@ -10,6 +10,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import variants from "./examples/variants";
 import input from "./examples/input";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -40,7 +41,7 @@ const sections = [
           <thead>
             <tr>
               <th>Variant</th>
-              <th>Description</th>
+              <HeaderCell>Description</HeaderCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/spinner/code/SpinnerCodePage.tsx
+++ b/website/screens/components/spinner/code/SpinnerCodePage.tsx
@@ -6,7 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import overlay from "./examples/overlay";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -16,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>label: string</td>

--- a/website/screens/components/spinner/code/SpinnerCodePage.tsx
+++ b/website/screens/components/spinner/code/SpinnerCodePage.tsx
@@ -6,6 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import overlay from "./examples/overlay";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>label: string</td>

--- a/website/screens/components/switch/code/SwitchCodePage.tsx
+++ b/website/screens/components/switch/code/SwitchCodePage.tsx
@@ -6,7 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -16,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>defaultChecked: boolean</td>

--- a/website/screens/components/switch/code/SwitchCodePage.tsx
+++ b/website/screens/components/switch/code/SwitchCodePage.tsx
@@ -6,6 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>defaultChecked: boolean</td>

--- a/website/screens/components/switch/usage/SwitchUsagePage.tsx
+++ b/website/screens/components/switch/usage/SwitchUsagePage.tsx
@@ -10,6 +10,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import labelPosition from "./examples/labelPosition";
 import stacking from "./examples/stacking";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -52,7 +53,7 @@ const sections = [
           <thead>
             <tr>
               <th>Position</th>
-              <th>Description</th>
+              <HeaderCell>Description</HeaderCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/switch/usage/SwitchUsagePage.tsx
+++ b/website/screens/components/switch/usage/SwitchUsagePage.tsx
@@ -10,7 +10,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import labelPosition from "./examples/labelPosition";
 import stacking from "./examples/stacking";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -53,7 +53,7 @@ const sections = [
           <thead>
             <tr>
               <th>Position</th>
-              <HeaderCell>Description</HeaderCell>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
             </tr>
           </thead>
           <tbody>

--- a/website/screens/components/table/code/TableCodePage.tsx
+++ b/website/screens/components/table/code/TableCodePage.tsx
@@ -4,7 +4,7 @@ import QuickNavContainer from "@/common/QuickNavContainer";
 import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basic from "./examples/basicUsage";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -14,7 +14,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>children: node</td>

--- a/website/screens/components/table/code/TableCodePage.tsx
+++ b/website/screens/components/table/code/TableCodePage.tsx
@@ -4,6 +4,7 @@ import QuickNavContainer from "@/common/QuickNavContainer";
 import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basic from "./examples/basicUsage";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -13,7 +14,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>children: node</td>

--- a/website/screens/components/tabs/code/TabsCodePage.tsx
+++ b/website/screens/components/tabs/code/TabsCodePage.tsx
@@ -7,6 +7,7 @@ import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import icons from "./examples/icons";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -16,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>tabs: object[]</td>

--- a/website/screens/components/tabs/code/TabsCodePage.tsx
+++ b/website/screens/components/tabs/code/TabsCodePage.tsx
@@ -7,7 +7,7 @@ import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import icons from "./examples/icons";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -17,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>tabs: object[]</td>

--- a/website/screens/components/tabs/specs/TabsSpecsPage.tsx
+++ b/website/screens/components/tabs/specs/TabsSpecsPage.tsx
@@ -18,6 +18,7 @@ import specsScrollable from "./images/tabs_scrollable.png";
 import specsNotification from "./images/tabs_notification.png";
 import statesTabs from "./images/tabs_states_specs.png";
 import specsAnatomy from "./images/tabs_anatomy.png";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -293,7 +294,7 @@ const sections = [
             <thead>
               <tr>
                 <th>key</th>
-                <th>description</th>
+                <HeaderCell>Description</HeaderCell>
               </tr>
             </thead>
             <tbody>

--- a/website/screens/components/tabs/specs/TabsSpecsPage.tsx
+++ b/website/screens/components/tabs/specs/TabsSpecsPage.tsx
@@ -18,7 +18,7 @@ import specsScrollable from "./images/tabs_scrollable.png";
 import specsNotification from "./images/tabs_notification.png";
 import statesTabs from "./images/tabs_states_specs.png";
 import specsAnatomy from "./images/tabs_anatomy.png";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -294,7 +294,7 @@ const sections = [
             <thead>
               <tr>
                 <th>key</th>
-                <HeaderCell>Description</HeaderCell>
+                <HeaderDescriptionCell>Description</HeaderDescriptionCell>
               </tr>
             </thead>
             <tbody>

--- a/website/screens/components/tag/code/TagCodePage.tsx
+++ b/website/screens/components/tag/code/TagCodePage.tsx
@@ -6,6 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import icons from "./examples/icons";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -15,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>label: string</td>

--- a/website/screens/components/tag/code/TagCodePage.tsx
+++ b/website/screens/components/tag/code/TagCodePage.tsx
@@ -6,7 +6,7 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import icons from "./examples/icons";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -16,7 +16,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>label: string</td>

--- a/website/screens/components/text-input/code/TextInputCodePage.tsx
+++ b/website/screens/components/text-input/code/TextInputCodePage.tsx
@@ -9,6 +9,7 @@ import uncontrolled from "./examples/uncontrolled";
 import action from "./examples/action";
 import functionSuggestions from "./examples/functionSuggestions";
 import errorHandling from "./examples/errorHandling";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -18,7 +19,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>defaultValue: string</td>

--- a/website/screens/components/text-input/code/TextInputCodePage.tsx
+++ b/website/screens/components/text-input/code/TextInputCodePage.tsx
@@ -9,7 +9,7 @@ import uncontrolled from "./examples/uncontrolled";
 import action from "./examples/action";
 import functionSuggestions from "./examples/functionSuggestions";
 import errorHandling from "./examples/errorHandling";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -19,7 +19,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>defaultValue: string</td>

--- a/website/screens/components/textarea/code/TextareaCodePage.tsx
+++ b/website/screens/components/textarea/code/TextareaCodePage.tsx
@@ -7,7 +7,7 @@ import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import errorHandling from "./examples/errorHandling";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -17,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>defaultValue: string</td>

--- a/website/screens/components/textarea/code/TextareaCodePage.tsx
+++ b/website/screens/components/textarea/code/TextareaCodePage.tsx
@@ -7,6 +7,7 @@ import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import errorHandling from "./examples/errorHandling";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -16,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>defaultValue: string</td>

--- a/website/screens/components/toggle-group/code/ToggleGroupCodePage.tsx
+++ b/website/screens/components/toggle-group/code/ToggleGroupCodePage.tsx
@@ -7,7 +7,7 @@ import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import icons from "./examples/icons";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -17,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>label: string</td>

--- a/website/screens/components/toggle-group/code/ToggleGroupCodePage.tsx
+++ b/website/screens/components/toggle-group/code/ToggleGroupCodePage.tsx
@@ -7,6 +7,7 @@ import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import icons from "./examples/icons";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -16,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>label: string</td>

--- a/website/screens/components/wizard/code/WizardCodePage.tsx
+++ b/website/screens/components/wizard/code/WizardCodePage.tsx
@@ -7,7 +7,7 @@ import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import icons from "./examples/icons";
-import HeaderCell from "@/common/HeaderCell";
+import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const sections = [
   {
@@ -17,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <HeaderCell>Description</HeaderCell>
+          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
         </tr>
         <tr>
           <td>mode: 'horizontal' | 'vertical'</td>

--- a/website/screens/components/wizard/code/WizardCodePage.tsx
+++ b/website/screens/components/wizard/code/WizardCodePage.tsx
@@ -7,6 +7,7 @@ import Example from "@/common/example/Example";
 import controlled from "./examples/controlled";
 import uncontrolled from "./examples/uncontrolled";
 import icons from "./examples/icons";
+import HeaderCell from "@/common/HeaderCell";
 
 const sections = [
   {
@@ -16,7 +17,7 @@ const sections = [
         <tr>
           <th>Name</th>
           <th>Default</th>
-          <th>Description</th>
+          <HeaderCell>Description</HeaderCell>
         </tr>
         <tr>
           <td>mode: 'horizontal' | 'vertical'</td>


### PR DESCRIPTION
Changed width from quick nav container to solve the problem with tables. Now tables can be scrollabled.

Before the change:
![image](https://user-images.githubusercontent.com/34685461/176656753-df59fb90-0966-4f54-aeaf-d707422f9f43.png)

After the change:
![image](https://user-images.githubusercontent.com/34685461/176656667-fd4093b8-9c78-4a60-a70d-1e6fbec90d5a.png)
