### PR TITLE
[Minor] Remove Inline `alignX` prop `stretch` and `baseline` values

### DIFF
--- a/lib/src/inline/Inline.stories.tsx
+++ b/lib/src/inline/Inline.stories.tsx
@@ -30,12 +30,12 @@ export const Chromatic = () => (
         <Placeholder height="medium" width="small" />
       </DxcInline>
     </Container>
-    <Title title="Default with one child" theme="light" level={4} />
-    <Container>
+    <Title title="One child larger than flex container" theme="light" level={4} />
+    <FlexContainer customWidth>
       <DxcInline>
-        <Placeholder height="large" width="large" />
+        <Placeholder height="large" width="xlarge" />
       </DxcInline>
-    </Container>
+    </FlexContainer>
     <Title title="Wrap" theme="light" level={4} />
     <Container customWidth>
       <DxcInline>
@@ -43,6 +43,15 @@ export const Chromatic = () => (
         <Placeholder height="large" width="medium" />
         <Placeholder height="medium" width="small" />
         <Placeholder height="large" width="medium" />
+      </DxcInline>
+    </Container>
+    <Title title="AlignY = start" theme="light" level={4} />
+    <Container>
+      <DxcInline alignY="stretch">
+        <Placeholder width="small" />
+        <Placeholder height="medium" width="medium" />
+        <Placeholder height="large" width="large" />
+        <Placeholder height="small" width="large" />
       </DxcInline>
     </Container>
     <Title title="AlignY = end" theme="light" level={4} />
@@ -63,6 +72,17 @@ export const Chromatic = () => (
         <Placeholder height="small" width="large" />
       </DxcInline>
     </Container>
+    <Title title="AlignY with wrapped items" theme="light" level={4} />
+    <Container customWidth>
+      <DxcInline alignY="end">
+        <Placeholder height="large" width="small" />
+        <Placeholder height="large" width="medium" />
+        <Placeholder height="medium" width="small" />
+        <Placeholder height="large" width="medium" />
+        <Placeholder height="medium" width="small" />
+        <Placeholder height="small" width="medium" />
+      </DxcInline>
+    </Container>
     <Title title="AlignY = baseline" theme="light" level={4} />
     <Container>
       <DxcInline alignY="baseline">
@@ -72,13 +92,13 @@ export const Chromatic = () => (
         <Placeholder height="small" width="large" />
       </DxcInline>
     </Container>
-    <Title title="AlignY = stretch" theme="light" level={4} />
+    <Title title="AlignX = start" theme="light" level={4} />
     <Container>
-      <DxcInline alignY="stretch">
-        <Placeholder width="small" />
+      <DxcInline alignX="start">
+        <Placeholder height="small" width="small" />
         <Placeholder height="medium" width="medium" />
         <Placeholder height="large" width="large" />
-        <Placeholder height="small" width="large" />
+        <Placeholder height="small" />
       </DxcInline>
     </Container>
     <Title title="AlignX = end" theme="light" level={4} />
@@ -100,22 +120,17 @@ export const Chromatic = () => (
         <Placeholder height="small" width="large" />
       </DxcInline>
     </Container>
-    <Title title="AlignX = baseline" theme="light" level={4} />
-    <Container>
-      <DxcInline alignX="baseline">
+    <Title title="AlignX with wrapped items" theme="light" level={4} />
+    <Container customWidth>
+      <DxcInline alignX="center">
         <Placeholder height="small" width="small" />
-        <Placeholder height="medium" width="medium" />
+        <Placeholder height="large" width="medium" />
+        <Placeholder height="medium" width="small" />
         <Placeholder height="large" width="large" />
+        <Placeholder height="medium" width="small" />
         <Placeholder height="small" width="large" />
-      </DxcInline>
-    </Container>
-    <Title title="AlignX = stretch" theme="light" level={4} />
-    <Container>
-      <DxcInline alignX="stretch">
-        <Placeholder height="small" width="small" />
-        <Placeholder height="medium" width="medium" />
         <Placeholder height="large" width="large" />
-        <Placeholder height="small" />
+        <Placeholder height="large" width="medium" />
       </DxcInline>
     </Container>
     <Title title="Gutter = 0.125rem" theme="light" level={4} />
@@ -201,20 +216,25 @@ export const Chromatic = () => (
   </>
 );
 
+const FlexContainer = styled.div<{ customWidth?: boolean }>`
+  display: flex;
+  ${({ customWidth }) => customWidth && `width: 200px;`};
+  background: #f2eafa;
+`;
+
 const Container = styled.div<{ customWidth?: boolean }>`
   background: #f2eafa;
-  ${({ customWidth }) => (customWidth ? `width: 300px;` : "")};
+  ${({ customWidth }) => customWidth && `width: 300px;`};
 `;
 
 type PlaceholderProps = {
-  width?: "large" | "medium" | "small" | "auto";
+  width?: "xlarge" | "large" | "medium" | "small" | "auto";
   height?: "large" | "medium" | "small" | "auto";
 };
 
 const Placeholder = styled.div<PlaceholderProps>`
-  ${({ width }) => (width ? `width: ${width === "large" ? "150px" : width === "medium" ? "100px" : "50px"};` : "")};
-  ${({ height }) =>
-    height ? `height: ${height === "large" ? "150px" : height === "medium" ? "100px" : "50px"};` : ""};
+  ${({ width }) => width && `width: ${width === "xlarge" ? "350px" : width === "large" ? "150px" : width === "medium" ? "100px" : "50px"};`};
+  ${({ height }) => height && `height: ${height === "large" ? "150px" : height === "medium" ? "100px" : "50px"};`};
   border: 1px solid #a46ede;
   background-color: #e5d5f6;
 `;

--- a/lib/src/inline/Inline.tsx
+++ b/lib/src/inline/Inline.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import InlineProps from "./types";
 
 const DxcInline = ({
-  alignX = "stretch",
+  alignX = "start",
   alignY = "stretch",
   as = "div",
   divider = false,

--- a/lib/src/inline/types.ts
+++ b/lib/src/inline/types.ts
@@ -2,7 +2,7 @@ type Props = {
   /**
    * Align children in the main axis.
    */
-  alignX?: "start" | "end" | "center" | "baseline" | "stretch";
+  alignX?: "start" | "end" | "center";
   /**
    * Align children in the cross axis.
    */


### PR DESCRIPTION
After some research, we find out that `justify-content` doesn't apply `stretch` and `baseline` values to the flexbox container and therefore there wasn't doing anything in the component at all.

See more in [MDN docs](https://developer.mozilla.org/es/docs/Web/CSS/justify-content) and [CSS-tricks flexbox guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).