### PR TITLE
Fixed examples overflow

### DIFF
--- a/website/screens/common/example/Example.tsx
+++ b/website/screens/common/example/Example.tsx
@@ -145,6 +145,10 @@ const StyledPreview = styled.div`
   border: 1px solid #707070;
   border-radius: 0.25rem;
   margin-bottom: 0.5rem;
+  overflow: auto;
+  > div {
+    width: fit-content;
+  }
 `;
 
 const StyledError = styled.div`


### PR DESCRIPTION
Added overflow to examples container to be able to scroll on them when the screen is small.

![image](https://user-images.githubusercontent.com/34685461/177297293-f51f05bf-601d-4774-83e1-55885c75eb44.png)
