### PR TITLE
Fixed too long subtitles

### DIFF
--- a/website/screens/common/HeadingLink.tsx
+++ b/website/screens/common/HeadingLink.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import slugify from "slugify";
 import { DxcHeading } from "@dxc-technology/halstack-react";
+import { responsiveSizes } from "../common/variables.js";
 
 type HeadingLinkProps = {
   children: string;
@@ -46,6 +47,10 @@ const HeadingLinkContainer = styled.div`
   scroll-margin-top: 64px;
   &:hover svg {
     opacity: 0.5;
+  }
+
+  @media (max-width: ${responsiveSizes.tablet}px) {
+    word-break: break-word;
   }
 `;
 


### PR DESCRIPTION
When subtitles are too long, the website can not be seen correctly in small devices:

![image](https://user-images.githubusercontent.com/34685461/177550188-326a112e-21b3-4440-b4b1-15dcc985b8a8.png)

Added `word-break: break-word`  to be more readable:

![image](https://user-images.githubusercontent.com/34685461/177550339-4a94d594-34dc-46f7-b4ad-8981f97773e1.png)

