### PR TITLE
Removed several warnings

### DIFF
--- a/lib/src/quick-nav/QuickNav.tsx
+++ b/lib/src/quick-nav/QuickNav.tsx
@@ -26,15 +26,17 @@ const DxcQuickNav = ({ title, links }: QuickNavTypes): JSX.Element => {
                   <DxcInset space="0.25rem">
                     <DxcText>
                       <Link href={`#${slugify(link?.label, { lower: true })}`}>{link?.label}</Link>
-                      {link.links?.map((sublink) => (
-                        <ListRow key={sublink.label}>
-                          <DxcInset horizontal="0.5rem">
-                            <DxcText>
-                              <Link href={`#${slugify(sublink?.label, { lower: true })}`}>{sublink?.label}</Link>
-                            </DxcText>
-                          </DxcInset>
-                        </ListRow>
-                      ))}
+                      <ListColumn>
+                        {link.links?.map((sublink) => (
+                          <ListRow key={sublink.label}>
+                            <DxcInset horizontal="0.5rem">
+                              <DxcText>
+                                <Link href={`#${slugify(sublink?.label, { lower: true })}`}>{sublink?.label}</Link>
+                              </DxcText>
+                            </DxcInset>
+                          </ListRow>
+                        ))}
+                      </ListColumn>
                     </DxcText>
                   </DxcInset>
                 </ListRow>

--- a/lib/src/quick-nav/QuickNav.tsx
+++ b/lib/src/quick-nav/QuickNav.tsx
@@ -22,12 +22,12 @@ const DxcQuickNav = ({ title, links }: QuickNavTypes): JSX.Element => {
           <ListColumn>
             <DxcStack gutter="0.5rem">
               {links.map((link) => (
-                <ListRow>
+                <ListRow key={link.label}>
                   <DxcInset space="0.25rem">
                     <DxcText>
                       <Link href={`#${slugify(link?.label, { lower: true })}`}>{link?.label}</Link>
                       {link.links?.map((sublink) => (
-                        <ListRow>
+                        <ListRow key={sublink.label}>
                           <DxcInset horizontal="0.5rem">
                             <DxcText>
                               <Link href={`#${slugify(sublink?.label, { lower: true })}`}>{sublink?.label}</Link>

--- a/website/screens/components/button/usage/examples/iconUsage.ts
+++ b/website/screens/components/button/usage/examples/iconUsage.ts
@@ -14,7 +14,7 @@ const code = `() => {
       width="24px"
       height="24px"
       viewBox="0 0 24 24"
-      enable-background="new 0 0 24 24"
+      enableBackground="new 0 0 24 24"
       fill="currentColor"
     >
       <g id="Bounding_Box">

--- a/website/screens/components/chip/code/examples/icons.ts
+++ b/website/screens/components/chip/code/examples/icons.ts
@@ -8,7 +8,7 @@ const code = `() => {
       width="24px"
       height="24px"
       viewBox="0 0 24 24"
-      enable-background="new 0 0 24 24"
+      enableBackground="new 0 0 24 24"
       fill="currentColor"
     >
       <g id="Bounding_Box">

--- a/website/screens/components/dropdown/usage/examples/iconUsage.ts
+++ b/website/screens/components/dropdown/usage/examples/iconUsage.ts
@@ -4,7 +4,7 @@ const code = `() => {
   const icon = (
     <svg
       viewBox="0 0 24 24"
-      enable-background="new 0 0 24 24"
+      enableBackground="new 0 0 24 24"
       fill="currentColor"
     >
       <g id="Bounding_Box">

--- a/website/screens/components/wizard/code/examples/icons.ts
+++ b/website/screens/components/wizard/code/examples/icons.ts
@@ -17,7 +17,7 @@ const code = `() => {
   const homeIcon = (
     <svg
       viewBox="0 0 24 24"
-      enable-background="new 0 0 24 24"
+      enableBackground="new 0 0 24 24"
       fill="currentColor"
     >
       <g id="Bounding_Box">


### PR DESCRIPTION
Removed QuickNav component warnings:
1. `<li>` cannot be descendant of `<li>`
2. `key` warning

Removed `enable-background` warning of several svgs.