### PR TITLE
Change actions visibility in site examples

### DIFF
--- a/website/screens/common/example/Example.tsx
+++ b/website/screens/common/example/Example.tsx
@@ -10,6 +10,7 @@ type Example = {
   code?: string;
 };
 type ExamplePropTypes = {
+  actionsVisible?: boolean;
   defaultIsVisible?: boolean;
   example: Example;
 };
@@ -42,6 +43,7 @@ const icons = {
 };
 
 const Example = ({
+  actionsVisible = true,
   defaultIsVisible = false,
   example,
 }: ExamplePropTypes): JSX.Element => {
@@ -93,22 +95,24 @@ const Example = ({
             <LiveError />
           </StyledError>
         </StyledPreview>
-        <CodeActionsContainer isCodeVisible={isCodeVisible}>
-          {isCodeVisible && (
+        {actionsVisible && (
+          <CodeActionsContainer isCodeVisible={isCodeVisible}>
+            {isCodeVisible && (
+              <DxcButton
+                label={"Copy code"}
+                icon={icons.copy}
+                mode="text"
+                onClick={copyCode}
+              />
+            )}
             <DxcButton
-              label={"Copy code"}
-              icon={icons.copy}
+              label={isCodeVisible ? "Hide code" : "View code"}
+              icon={icons.code}
               mode="text"
-              onClick={copyCode}
+              onClick={handleCodeOnClick}
             />
-          )}
-          <DxcButton
-            label={isCodeVisible ? "Hide code" : "View code"}
-            icon={icons.code}
-            mode="text"
-            onClick={handleCodeOnClick}
-          />
-        </CodeActionsContainer>
+          </CodeActionsContainer>
+        )}
         {isCodeVisible && (
           <LiveEditorContainer ref={liveEditorRef}>
             {copied && (

--- a/website/screens/components/application-layout/code/ApplicationLayoutCodePage.tsx
+++ b/website/screens/components/application-layout/code/ApplicationLayoutCodePage.tsx
@@ -142,15 +142,17 @@ const sections = [
     subSections: [
       {
         title: "Basic usage",
-        content: <Example example={basicUsage} />,
+        content: <Example example={basicUsage} actionsVisible={false} />,
       },
       {
         title: "With sidenav",
-        content: <Example example={withSidenav} />,
+        content: <Example example={withSidenav} actionsVisible={false} />,
       },
       {
         title: "Custom header and footer",
-        content: <Example example={customHeaderFooter} />,
+        content: (
+          <Example example={customHeaderFooter} actionsVisible={false} />
+        ),
       },
     ],
   },


### PR DESCRIPTION
Now in the examples it is possible to hide the `Copy code` and `View code` actions. 
In the examples of the application layout they are hided.