### PR TITLE
Removed table warning in all site pages

### DIFF
--- a/lib/src/accordion-group/AccordionGroup.tsx
+++ b/lib/src/accordion-group/AccordionGroup.tsx
@@ -60,7 +60,7 @@ const DxcAccordionGroup = ({
         {(Array.isArray(children) ? children : [children])
           .filter((child) => child.type === AccordionGroupAccordion)
           .map((accordion, index) => (
-            <AccordionGroupAccordionContext.Provider value={{ index, ...contextValue }}>
+            <AccordionGroupAccordionContext.Provider key={`accordion-${index}`} value={{ index, ...contextValue }}>
               {accordion}
             </AccordionGroupAccordionContext.Provider>
           ))}

--- a/website/screens/components/accordion/code/AccordionCodePage.tsx
+++ b/website/screens/components/accordion/code/AccordionCodePage.tsx
@@ -19,95 +19,103 @@ const sections = [
         title: "Accordion",
         content: (
           <DxcTable>
-            <tr>
-              <th>Name</th>
-              <th>Default</th>
-              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-            </tr>
-            <tr>
-              <td>label: string</td>
-              <td></td>
-              <td>The panel label.</td>
-            </tr>
-            <tr>
-              <td>icon: node | string</td>
-              <td></td>
-              <td>
-                Element or path used as the icon that will be placed next to
-                panel label.
-              </td>
-            </tr>
-            <tr>
-              <td>assistiveText: string</td>
-              <td></td>
-              <td>
-                Assistive text to be placed on the right side of the panel.
-              </td>
-            </tr>
-            <tr>
-              <td>disabled: boolean</td>
-              <td>
-                <Code>false</Code>
-              </td>
-              <td>If true, the component will be disabled.</td>
-            </tr>
-            <tr>
-              <td>defaultIsExpanded: boolean</td>
-              <td></td>
-              <td>Initial state of the panel, only when it is uncontrolled.</td>
-            </tr>
-            <tr>
-              <td>isExpanded: boolean</td>
-              <td></td>
-              <td>
-                Represents the state of the panel. When true, the component will
-                be expanded. If undefined, the component will be uncontrolled
-                and its value will be managed internally by the component.
-              </td>
-            </tr>
-            <tr>
-              <td>onChange: function</td>
-              <td></td>
-              <td>
-                This function will be called when the user clicks the accordion
-                to expand or collapse the panel. The new state of the panel will
-                be passed as a parameter.
-              </td>
-            </tr>
-            <tr>
-              <td>children: node</td>
-              <td></td>
-              <td>
-                The expanded panel of the accordion. This area can be used to
-                render custom content.
-              </td>
-            </tr>
-            <tr>
-              <td>margin: string | object</td>
-              <td></td>
-              <td>
-                Size of the margin to be applied to the component ('xxsmall' |
-                'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
-                You can pass an object with 'top', 'bottom', 'left' and 'right'
-                properties in order to specify different margin sizes.
-              </td>
-            </tr>
-            <tr>
-              <td>padding: string | object</td>
-              <td></td>
-              <td>
-                Size of the padding to be applied to the custom area ('xxsmall'
-                | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' |
-                'xxlarge'). You can pass an object with 'top', 'bottom', 'left'
-                and 'right' properties in order to specify different padding
-                sizes.
-              </td>
-            </tr>
-            <tr>
-              <td>tabIndex: number</td>
-              <td>0</td>
-              <td>Value of the tabindex.</td>
-            </tr>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Default</th>
+                <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>label: string</td>
+                <td></td>
+                <td>The panel label.</td>
+              </tr>
+              <tr>
+                <td>icon: node | string</td>
+                <td></td>
+                <td>
+                  Element or path used as the icon that will be placed next to
+                  panel label.
+                </td>
+              </tr>
+              <tr>
+                <td>assistiveText: string</td>
+                <td></td>
+                <td>
+                  Assistive text to be placed on the right side of the panel.
+                </td>
+              </tr>
+              <tr>
+                <td>disabled: boolean</td>
+                <td>
+                  <Code>false</Code>
+                </td>
+                <td>If true, the component will be disabled.</td>
+              </tr>
+              <tr>
+                <td>defaultIsExpanded: boolean</td>
+                <td></td>
+                <td>
+                  Initial state of the panel, only when it is uncontrolled.
+                </td>
+              </tr>
+              <tr>
+                <td>isExpanded: boolean</td>
+                <td></td>
+                <td>
+                  Represents the state of the panel. When true, the component
+                  will be expanded. If undefined, the component will be
+                  uncontrolled and its value will be managed internally by the
+                  component.
+                </td>
+              </tr>
+              <tr>
+                <td>onChange: function</td>
+                <td></td>
+                <td>
+                  This function will be called when the user clicks the
+                  accordion to expand or collapse the panel. The new state of
+                  the panel will be passed as a parameter.
+                </td>
+              </tr>
+              <tr>
+                <td>children: node</td>
+                <td></td>
+                <td>
+                  The expanded panel of the accordion. This area can be used to
+                  render custom content.
+                </td>
+              </tr>
+              <tr>
+                <td>margin: string | object</td>
+                <td></td>
+                <td>
+                  Size of the margin to be applied to the component ('xxsmall' |
+                  'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' |
+                  'xxlarge'). You can pass an object with 'top', 'bottom',
+                  'left' and 'right' properties in order to specify different
+                  margin sizes.
+                </td>
+              </tr>
+              <tr>
+                <td>padding: string | object</td>
+                <td></td>
+                <td>
+                  Size of the padding to be applied to the custom area
+                  ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' |
+                  'xlarge' | 'xxlarge'). You can pass an object with 'top',
+                  'bottom', 'left' and 'right' properties in order to specify
+                  different padding sizes.
+                </td>
+              </tr>
+              <tr>
+                <td>tabIndex: number</td>
+                <td>0</td>
+                <td>Value of the tabindex.</td>
+              </tr>
+            </tbody>
           </DxcTable>
         ),
       },
@@ -115,52 +123,59 @@ const sections = [
         title: "Accordion Group",
         content: (
           <DxcTable>
-            <tr>
-              <th>Name</th>
-              <th>Default</th>
-              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-            </tr>
-            <tr>
-              <td>defaultIndexActive: number</td>
-              <td></td>
-              <td>Initially active accordion, only when it is uncontrolled.</td>
-            </tr>
-            <tr>
-              <td>indexActive: number</td>
-              <td></td>
-              <td>
-                The index of the active accordion. If undefined, the component
-                will be uncontrolled and the active accordion will be managed
-                internally by the component. If null, the component will be
-                controlled and all accordions will be closed.
-              </td>
-            </tr>
-            <tr>
-              <td>disabled: boolean</td>
-              <td>
-                <Code>false</Code>
-              </td>
-              <td>If true, the component will be disabled.</td>
-            </tr>
-            <tr>
-              <td>onActiveChange: function</td>
-              <td></td>
-              <td>
-                This function will be called when the user clicks on an
-                accordion. The index of the clicked accordion will be passed as
-                a parameter.
-              </td>
-            </tr>
-            <tr>
-              <td>margin: string | object</td>
-              <td></td>
-              <td>
-                Size of the margin to be applied to the component ('xxsmall' |
-                'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
-                You can pass an object with 'top', 'bottom', 'left' and 'right'
-                properties in order to specify different margin sizes.
-              </td>
-            </tr>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Default</th>
+                <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>defaultIndexActive: number</td>
+                <td></td>
+                <td>
+                  Initially active accordion, only when it is uncontrolled.
+                </td>
+              </tr>
+              <tr>
+                <td>indexActive: number</td>
+                <td></td>
+                <td>
+                  The index of the active accordion. If undefined, the component
+                  will be uncontrolled and the active accordion will be managed
+                  internally by the component. If null, the component will be
+                  controlled and all accordions will be closed.
+                </td>
+              </tr>
+              <tr>
+                <td>disabled: boolean</td>
+                <td>
+                  <Code>false</Code>
+                </td>
+                <td>If true, the component will be disabled.</td>
+              </tr>
+              <tr>
+                <td>onActiveChange: function</td>
+                <td></td>
+                <td>
+                  This function will be called when the user clicks on an
+                  accordion. The index of the clicked accordion will be passed
+                  as a parameter.
+                </td>
+              </tr>
+              <tr>
+                <td>margin: string | object</td>
+                <td></td>
+                <td>
+                  Size of the margin to be applied to the component ('xxsmall' |
+                  'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' |
+                  'xxlarge'). You can pass an object with 'top', 'bottom',
+                  'left' and 'right' properties in order to specify different
+                  margin sizes.
+                </td>
+              </tr>
+            </tbody>
           </DxcTable>
         ),
         subSections: [
@@ -177,58 +192,64 @@ const sections = [
                 title: "Props",
                 content: (
                   <DxcTable>
-                    <tr>
-                      <th>Name</th>
-                      <th>Default</th>
-                      <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-                    </tr>
-                    <tr>
-                      <td>label: string</td>
-                      <td></td>
-                      <td>The panel label.</td>
-                    </tr>
-                    <tr>
-                      <td>icon: node | string</td>
-                      <td></td>
-                      <td>
-                        Element or path used as the icon that will be placed
-                        next to panel label.
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>assistiveText: string</td>
-                      <td></td>
-                      <td>
-                        Assistive text to be placed on the right side of the
-                        panel.
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>disabled: boolean</td>
-                      <td>
-                        <Code>false</Code>
-                      </td>
-                      <td>If true, the component will be disabled.</td>
-                    </tr>
-                    <tr>
-                      <td>children: node</td>
-                      <td></td>
-                      <td>
-                        The expanded panel of the accordion. This area can be
-                        used to render custom content.
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>padding: string | object</td>
-                      <td></td>
-                      <td>
-                        Size of the padding to be applied to the custom area
-                        ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' |
-                        'xlarge' | 'xxlarge'). You can pass an object with
-                        'top', 'bottom', 'left' and 'right' properties in order
-                        to specify different padding sizes.
-                      </td>
-                    </tr>
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Default</th>
+                        <HeaderDescriptionCell>
+                          Description
+                        </HeaderDescriptionCell>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>label: string</td>
+                        <td></td>
+                        <td>The panel label.</td>
+                      </tr>
+                      <tr>
+                        <td>icon: node | string</td>
+                        <td></td>
+                        <td>
+                          Element or path used as the icon that will be placed
+                          next to panel label.
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>assistiveText: string</td>
+                        <td></td>
+                        <td>
+                          Assistive text to be placed on the right side of the
+                          panel.
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>disabled: boolean</td>
+                        <td>
+                          <Code>false</Code>
+                        </td>
+                        <td>If true, the component will be disabled.</td>
+                      </tr>
+                      <tr>
+                        <td>children: node</td>
+                        <td></td>
+                        <td>
+                          The expanded panel of the accordion. This area can be
+                          used to render custom content.
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>padding: string | object</td>
+                        <td></td>
+                        <td>
+                          Size of the padding to be applied to the custom area
+                          ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' |
+                          'xlarge' | 'xxlarge'). You can pass an object with
+                          'top', 'bottom', 'left' and 'right' properties in
+                          order to specify different padding sizes.
+                        </td>
+                      </tr>
+                    </tbody>
                   </DxcTable>
                 ),
               },

--- a/website/screens/components/alert/code/AlertCodePage.tsx
+++ b/website/screens/components/alert/code/AlertCodePage.tsx
@@ -13,90 +13,98 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>type: 'info' | 'confirm' | 'warning' | 'error'</td>
-          <td>
-            <Code>'info'</Code>
-          </td>
-          <td>Uses on of the available alert types.</td>
-        </tr>
-        <tr>
-          <td>mode: 'inline' | 'modal'</td>
-          <td>
-            <Code>'inline'</Code>
-          </td>
-          <td>
-            Uses on of the available alert modes:
-            <ul>
-              <li>
-                <strong>inline:</strong> If onClose function is received, close
-                button will be visible and the function will be executed when
-                it's clicked. There is no overlay layer. Position should be
-                decided by the user.
-              </li>
-              <li>
-                <strong>modal:</strong> The alert will be displayed in the
-                middle of the screen with an overlay layer behind. The onClose
-                function will be executed when the X button or the overlay is
-                clicked. The user has the responsibility of hidding the modal in
-                the onClose function, otherwise the modal will remain visible.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>inlineText: string</td>
-          <td></td>
-          <td>Text to display after icon and alert type and before content.</td>
-        </tr>
-        <tr>
-          <td>onClose: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user clicks the close button.
-            If there is no function we should close the alert by default.
-          </td>
-        </tr>
-        <tr>
-          <td>children: node</td>
-          <td></td>
-          <td>
-            The details section of the alert. Can be used to render custom
-            content in this area.
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>size: string</td>
-          <td>
-            <Code>'fitContent'</Code>
-          </td>
-          <td>
-            Size of the component ('small' | 'medium' | 'large' | 'fillParent' |
-            'fitContent').
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Tabindex value given to the close button.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>type: 'info' | 'confirm' | 'warning' | 'error'</td>
+            <td>
+              <Code>'info'</Code>
+            </td>
+            <td>Uses on of the available alert types.</td>
+          </tr>
+          <tr>
+            <td>mode: 'inline' | 'modal'</td>
+            <td>
+              <Code>'inline'</Code>
+            </td>
+            <td>
+              Uses on of the available alert modes:
+              <ul>
+                <li>
+                  <strong>inline:</strong> If onClose function is received,
+                  close button will be visible and the function will be executed
+                  when it's clicked. There is no overlay layer. Position should
+                  be decided by the user.
+                </li>
+                <li>
+                  <strong>modal:</strong> The alert will be displayed in the
+                  middle of the screen with an overlay layer behind. The onClose
+                  function will be executed when the X button or the overlay is
+                  clicked. The user has the responsibility of hidding the modal
+                  in the onClose function, otherwise the modal will remain
+                  visible.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>inlineText: string</td>
+            <td></td>
+            <td>
+              Text to display after icon and alert type and before content.
+            </td>
+          </tr>
+          <tr>
+            <td>onClose: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user clicks the close
+              button. If there is no function we should close the alert by
+              default.
+            </td>
+          </tr>
+          <tr>
+            <td>children: node</td>
+            <td></td>
+            <td>
+              The details section of the alert. Can be used to render custom
+              content in this area.
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>size: string</td>
+            <td>
+              <Code>'fitContent'</Code>
+            </td>
+            <td>
+              Size of the component ('small' | 'medium' | 'large' | 'fillParent'
+              | 'fitContent').
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Tabindex value given to the close button.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/application-layout/code/ApplicationLayoutCodePage.tsx
+++ b/website/screens/components/application-layout/code/ApplicationLayoutCodePage.tsx
@@ -16,47 +16,55 @@ import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
 
 const ApplicationLayoutPropsTable = () => (
   <DxcTable>
-    <tr>
-      <th>Name</th>
-      <th>Default</th>
-      <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-    </tr>
-    <tr>
-      <td>visibilityToggleLabel: string</td>
-      <td></td>
-      <td>
-        Text to be placed next to the hamburger button that toggles the
-        visibility of the sidenav.
-      </td>
-    </tr>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Default</th>
+        <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>visibilityToggleLabel: string</td>
+        <td></td>
+        <td>
+          Text to be placed next to the hamburger button that toggles the
+          visibility of the sidenav.
+        </td>
+      </tr>
+    </tbody>
   </DxcTable>
 );
 
 const SidenavApplicationLayoutPropsTable = () => (
   <DxcTable>
-    <tr>
-      <th>Name</th>
-      <th>Default</th>
-      <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-    </tr>
-    <tr>
-      <td>padding: string | object</td>
-      <td></td>
-      <td>
-        Size of the padding to be applied to the custom area ('xxsmall' |
-        'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You can
-        pass an object with 'top', 'bottom', 'left' and 'right' properties in
-        order to specify different padding sizes.
-      </td>
-    </tr>
-    <tr>
-      <td>children: React.ReactNode</td>
-      <td></td>
-      <td>
-        The area inside the sidenav. This area can be used to render custom
-        content.
-      </td>
-    </tr>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Default</th>
+        <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>padding: string | object</td>
+        <td></td>
+        <td>
+          Size of the padding to be applied to the custom area ('xxsmall' |
+          'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
+          can pass an object with 'top', 'bottom', 'left' and 'right' properties
+          in order to specify different padding sizes.
+        </td>
+      </tr>
+      <tr>
+        <td>children: React.ReactNode</td>
+        <td></td>
+        <td>
+          The area inside the sidenav. This area can be used to render custom
+          content.
+        </td>
+      </tr>
+    </tbody>
   </DxcTable>
 );
 

--- a/website/screens/components/button/code/ButtonCodePage.tsx
+++ b/website/screens/components/button/code/ButtonCodePage.tsx
@@ -13,84 +13,90 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>mode: 'primary' | 'secondary' | 'text'</td>
-          <td>
-            <Code>'primary'</Code>
-          </td>
-          <td>Uses one of the available button modes.</td>
-        </tr>
-        <tr>
-          <td>type: 'button' | 'reset' | 'submit'</td>
-          <td>
-            <Code>'button'</Code>
-          </td>
-          <td>
-            This prop corresponds to the 'type' prop of the button in html.
-          </td>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed next to the button.</td>
-        </tr>
-        <tr>
-          <td>icon: node | string</td>
-          <td></td>
-          <td>
-            Element or path used as the icon that will be placed next to the
-            button label.
-          </td>
-        </tr>
-        <tr>
-          <td>iconPosition: 'before' | 'after'</td>
-          <td>
-            <Code>'before'</Code>
-          </td>
-          <td>Whether the icon should appear after or before the label.</td>
-        </tr>
-        <tr>
-          <td>disabled: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the component will be disabled.</td>
-        </tr>
-        <tr>
-          <td>onClick: function</td>
-          <td></td>
-          <td>This function will be called when the user clicks the button.</td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>size: string </td>
-          <td>
-            <Code>'fitContent'</Code>
-          </td>
-          <td>
-            Size of the component ('small' | 'medium' | 'large' | 'fillParent' |
-            'fitContent').
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>0</td>
-          <td>Value of the tabindex attribute.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>mode: 'primary' | 'secondary' | 'text'</td>
+            <td>
+              <Code>'primary'</Code>
+            </td>
+            <td>Uses one of the available button modes.</td>
+          </tr>
+          <tr>
+            <td>type: 'button' | 'reset' | 'submit'</td>
+            <td>
+              <Code>'button'</Code>
+            </td>
+            <td>
+              This prop corresponds to the 'type' prop of the button in html.
+            </td>
+          </tr>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed next to the button.</td>
+          </tr>
+          <tr>
+            <td>icon: node | string</td>
+            <td></td>
+            <td>
+              Element or path used as the icon that will be placed next to the
+              button label.
+            </td>
+          </tr>
+          <tr>
+            <td>iconPosition: 'before' | 'after'</td>
+            <td>
+              <Code>'before'</Code>
+            </td>
+            <td>Whether the icon should appear after or before the label.</td>
+          </tr>
+          <tr>
+            <td>disabled: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the component will be disabled.</td>
+          </tr>
+          <tr>
+            <td>onClick: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user clicks the button.
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>size: string </td>
+            <td>
+              <Code>'fitContent'</Code>
+            </td>
+            <td>
+              Size of the component ('small' | 'medium' | 'large' | 'fillParent'
+              | 'fitContent').
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>0</td>
+            <td>Value of the tabindex attribute.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/checkbox/code/CheckboxCodePage.tsx
+++ b/website/screens/components/checkbox/code/CheckboxCodePage.tsx
@@ -13,105 +13,113 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>defaultChecked: boolean</td>
-          <td></td>
-          <td>Initial state of the checkbox, only when it is uncontrolled.</td>
-        </tr>
-        <tr>
-          <td>checked: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, the component is checked. If undefined the component will
-            be uncontrolled and the value will be managed internally by the
-            component.
-          </td>
-        </tr>
-        <tr>
-          <td>value: string</td>
-          <td></td>
-          <td>
-            Will be passed to the value attribute of the html input element.
-            When inside a form, this value will be only submitted if the
-            checkbox is checked.
-          </td>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed next to the checkbox.</td>
-        </tr>
-        <tr>
-          <td>labelPosition: 'before' | 'after'</td>
-          <td>
-            <Code>'before'</Code>
-          </td>
-          <td>Whether the label should appear after or before the checkbox.</td>
-        </tr>
-        <tr>
-          <td>name: string</td>
-          <td></td>
-          <td>Name attribute of the input element.</td>
-        </tr>
-        <tr>
-          <td>disabled: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the component will be disabled.</td>
-        </tr>
-        <tr>
-          <td>optional: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, the component will display <Code>(Optional)</Code> next to
-            the label.
-          </td>
-        </tr>
-        <tr>
-          <td>onChange: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user clicks the checkbox. The
-            new value will be passed as a parameter.
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>size: string</td>
-          <td>
-            <Code>'fitContent'</Code>
-          </td>
-          <td>
-            Size of the component ('small' | 'medium' | 'large' | 'fillParent' |
-            'fitContent').
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>defaultChecked: boolean</td>
+            <td></td>
+            <td>
+              Initial state of the checkbox, only when it is uncontrolled.
+            </td>
+          </tr>
+          <tr>
+            <td>checked: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, the component is checked. If undefined the component will
+              be uncontrolled and the value will be managed internally by the
+              component.
+            </td>
+          </tr>
+          <tr>
+            <td>value: string</td>
+            <td></td>
+            <td>
+              Will be passed to the value attribute of the html input element.
+              When inside a form, this value will be only submitted if the
+              checkbox is checked.
+            </td>
+          </tr>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed next to the checkbox.</td>
+          </tr>
+          <tr>
+            <td>labelPosition: 'before' | 'after'</td>
+            <td>
+              <Code>'before'</Code>
+            </td>
+            <td>
+              Whether the label should appear after or before the checkbox.
+            </td>
+          </tr>
+          <tr>
+            <td>name: string</td>
+            <td></td>
+            <td>Name attribute of the input element.</td>
+          </tr>
+          <tr>
+            <td>disabled: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the component will be disabled.</td>
+          </tr>
+          <tr>
+            <td>optional: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, the component will display <Code>(Optional)</Code> next
+              to the label.
+            </td>
+          </tr>
+          <tr>
+            <td>onChange: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user clicks the checkbox.
+              The new value will be passed as a parameter.
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>size: string</td>
+            <td>
+              <Code>'fitContent'</Code>
+            </td>
+            <td>
+              Size of the component ('small' | 'medium' | 'large' | 'fillParent'
+              | 'fitContent').
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/chip/code/ChipCodePage.tsx
+++ b/website/screens/components/chip/code/ChipCodePage.tsx
@@ -13,63 +13,67 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed on the chip.</td>
-        </tr>
-        <tr>
-          <td>prefixIcon: node | string</td>
-          <td></td>
-          <td>Element used as icon to be placed before the chip label.</td>
-        </tr>
-        <tr>
-          <td>suffixIcon: node | string</td>
-          <td></td>
-          <td>Element used as icon to be placed after the chip label.</td>
-        </tr>
-        <tr>
-          <td>onClickPrefix: function</td>
-          <td></td>
-          <td>This function will be called when the prefix is clicked.</td>
-        </tr>
-        <tr>
-          <td>onClickSuffix: function</td>
-          <td></td>
-          <td>This function will be called when the suffix is clicked.</td>
-        </tr>
-        <tr>
-          <td>disabled: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the component will be disabled.</td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>
-            Value of the tabindex, it also applies to prefix and suffix icons
-            when a function is given.
-          </td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed on the chip.</td>
+          </tr>
+          <tr>
+            <td>prefixIcon: node | string</td>
+            <td></td>
+            <td>Element used as icon to be placed before the chip label.</td>
+          </tr>
+          <tr>
+            <td>suffixIcon: node | string</td>
+            <td></td>
+            <td>Element used as icon to be placed after the chip label.</td>
+          </tr>
+          <tr>
+            <td>onClickPrefix: function</td>
+            <td></td>
+            <td>This function will be called when the prefix is clicked.</td>
+          </tr>
+          <tr>
+            <td>onClickSuffix: function</td>
+            <td></td>
+            <td>This function will be called when the suffix is clicked.</td>
+          </tr>
+          <tr>
+            <td>disabled: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the component will be disabled.</td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>
+              Value of the tabindex, it also applies to prefix and suffix icons
+              when a function is given.
+            </td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/dialog/code/DialogCodePage.tsx
+++ b/website/screens/components/dialog/code/DialogCodePage.tsx
@@ -14,71 +14,76 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>isCloseVisible: boolean</td>
-          <td>
-            <Code>true</Code>
-          </td>
-          <td>If true, the close 'x' button will be visible.</td>
-        </tr>
-        <tr>
-          <td>onCloseClick: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user clicks the close 'x'
-            button. The responsibility of hiding the dialog lies with the user.
-          </td>
-        </tr>
-        <tr>
-          <td>onBackgroundClick: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user clicks background. The
-            responsibility of hiding the dialog lies with the user.
-          </td>
-        </tr>
-        <tr>
-          <td>overlay: boolean</td>
-          <td>
-            <Code>true</Code>
-          </td>
-          <td>
-            If true, the dialog will be displayed over a darker background that
-            covers the content behind.
-          </td>
-        </tr>
-        <tr>
-          <td>padding: string | object</td>
-          <td>
-            <Code>'small'</Code>
-          </td>
-          <td>
-            Size of the padding to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different padding sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex given to the close 'x' button.</td>
-        </tr>
-        <tr>
-          <td>children: node</td>
-          <td></td>
-          <td>
-            The area inside the dialog. This area can be used to render custom
-            content.
-          </td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>isCloseVisible: boolean</td>
+            <td>
+              <Code>true</Code>
+            </td>
+            <td>If true, the close 'x' button will be visible.</td>
+          </tr>
+          <tr>
+            <td>onCloseClick: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user clicks the close 'x'
+              button. The responsibility of hiding the dialog lies with the
+              user.
+            </td>
+          </tr>
+          <tr>
+            <td>onBackgroundClick: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user clicks background. The
+              responsibility of hiding the dialog lies with the user.
+            </td>
+          </tr>
+          <tr>
+            <td>overlay: boolean</td>
+            <td>
+              <Code>true</Code>
+            </td>
+            <td>
+              If true, the dialog will be displayed over a darker background
+              that covers the content behind.
+            </td>
+          </tr>
+          <tr>
+            <td>padding: string | object</td>
+            <td>
+              <Code>'small'</Code>
+            </td>
+            <td>
+              Size of the padding to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different padding sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex given to the close 'x' button.</td>
+          </tr>
+          <tr>
+            <td>children: node</td>
+            <td></td>
+            <td>
+              The area inside the dialog. This area can be used to render custom
+              content.
+            </td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/dropdown/code/DropdownCodePage.tsx
+++ b/website/screens/components/dropdown/code/DropdownCodePage.tsx
@@ -14,119 +14,125 @@ const sections = [
     content: (
       <>
         <DxcTable>
-          <tr>
-            <th>Name</th>
-            <th>Default</th>
-            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-          </tr>
-          <tr>
-            <td>options: object[]</td>
-            <td></td>
-            <td>
-              An array of objects representing the options. Each object has the
-              following properties:
-              <ul>
-                <li>
-                  <b>label</b>: Option display value.
-                </li>
-                <li>
-                  <b>icon</b>: Element or path used as the icon that will be
-                  placed next to the option label.
-                </li>
-                <li>
-                  <b>value</b>: Option inner value.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>optionsIconPosition: 'before' | 'after'</td>
-            <td>
-              <Code>'before'</Code>
-            </td>
-            <td>
-              In case options include icons, whether the icon should appear
-              after or before the label.
-            </td>
-          </tr>
-          <tr>
-            <td>icon: node | string</td>
-            <td></td>
-            <td>
-              Element or path used as the icon that will be placed next to the
-              dropdown label.
-            </td>
-          </tr>
-          <tr>
-            <td>iconPosition: 'before' | 'after'</td>
-            <td>
-              <Code>'before'</Code>
-            </td>
-            <td>Whether the icon should appear after or before the label.</td>
-          </tr>
-          <tr>
-            <td>label: string</td>
-            <td></td>
-            <td>Text to be placed within the dropdown.</td>
-          </tr>
-          <tr>
-            <td>caretHidden: boolean</td>
-            <td>
-              <Code>false</Code>
-            </td>
-            <td>
-              Whether the arrow next to the label must be displayed or not.
-            </td>
-          </tr>
-          <tr>
-            <td>onSelectOption: function</td>
-            <td></td>
-            <td>
-              This function will be called every time the selection changes. The
-              value of the selected option will be passed as a parameter.
-            </td>
-          </tr>
-          <tr>
-            <td>expandOnHover: boolean</td>
-            <td>
-              <Code>false</Code>
-            </td>
-            <td>If true, the options are showed when the dropdown is hover.</td>
-          </tr>
-          <tr>
-            <td>margin: string | object</td>
-            <td></td>
-            <td>
-              Size of the margin to be applied to the component ('xxsmall' |
-              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
-              You can pass an object with 'top', 'bottom', 'left' and 'right'
-              properties in order to specify different margin sizes.
-            </td>
-          </tr>
-          <tr>
-            <td>size: string</td>
-            <td>
-              <Code>'fitContent'</Code>
-            </td>
-            <td>
-              Size of the component ('small' | 'medium' | 'large' | 'fitContent'
-              | 'fillParent' ).
-            </td>
-          </tr>
-          <tr>
-            <td>tabIndex: number</td>
-            <td>
-              <Code>0</Code>
-            </td>
-            <td>Value of the tabindex.</td>
-          </tr>
-          <tr>
-            <td>disabled: boolean</td>
-            <td>
-              <Code>false</Code>
-            </td>
-            <td>If true, the component will be disabled.</td>
-          </tr>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Default</th>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>options: object[]</td>
+              <td></td>
+              <td>
+                An array of objects representing the options. Each object has
+                the following properties:
+                <ul>
+                  <li>
+                    <b>label</b>: Option display value.
+                  </li>
+                  <li>
+                    <b>icon</b>: Element or path used as the icon that will be
+                    placed next to the option label.
+                  </li>
+                  <li>
+                    <b>value</b>: Option inner value.
+                  </li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td>optionsIconPosition: 'before' | 'after'</td>
+              <td>
+                <Code>'before'</Code>
+              </td>
+              <td>
+                In case options include icons, whether the icon should appear
+                after or before the label.
+              </td>
+            </tr>
+            <tr>
+              <td>icon: node | string</td>
+              <td></td>
+              <td>
+                Element or path used as the icon that will be placed next to the
+                dropdown label.
+              </td>
+            </tr>
+            <tr>
+              <td>iconPosition: 'before' | 'after'</td>
+              <td>
+                <Code>'before'</Code>
+              </td>
+              <td>Whether the icon should appear after or before the label.</td>
+            </tr>
+            <tr>
+              <td>label: string</td>
+              <td></td>
+              <td>Text to be placed within the dropdown.</td>
+            </tr>
+            <tr>
+              <td>caretHidden: boolean</td>
+              <td>
+                <Code>false</Code>
+              </td>
+              <td>
+                Whether the arrow next to the label must be displayed or not.
+              </td>
+            </tr>
+            <tr>
+              <td>onSelectOption: function</td>
+              <td></td>
+              <td>
+                This function will be called every time the selection changes.
+                The value of the selected option will be passed as a parameter.
+              </td>
+            </tr>
+            <tr>
+              <td>expandOnHover: boolean</td>
+              <td>
+                <Code>false</Code>
+              </td>
+              <td>
+                If true, the options are showed when the dropdown is hover.
+              </td>
+            </tr>
+            <tr>
+              <td>margin: string | object</td>
+              <td></td>
+              <td>
+                Size of the margin to be applied to the component ('xxsmall' |
+                'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+                You can pass an object with 'top', 'bottom', 'left' and 'right'
+                properties in order to specify different margin sizes.
+              </td>
+            </tr>
+            <tr>
+              <td>size: string</td>
+              <td>
+                <Code>'fitContent'</Code>
+              </td>
+              <td>
+                Size of the component ('small' | 'medium' | 'large' |
+                'fitContent' | 'fillParent' ).
+              </td>
+            </tr>
+            <tr>
+              <td>tabIndex: number</td>
+              <td>
+                <Code>0</Code>
+              </td>
+              <td>Value of the tabindex.</td>
+            </tr>
+            <tr>
+              <td>disabled: boolean</td>
+              <td>
+                <Code>false</Code>
+              </td>
+              <td>If true, the component will be disabled.</td>
+            </tr>
+          </tbody>
         </DxcTable>
       </>
     ),

--- a/website/screens/components/file-input/code/FileInputCodePage.tsx
+++ b/website/screens/components/file-input/code/FileInputCodePage.tsx
@@ -13,151 +13,155 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>name: string</td>
-          <td></td>
-          <td>Name attribute.</td>
-        </tr>
-        <tr>
-          <td>mode: 'file' | 'filedrop' | 'dropzone'</td>
-          <td>
-            <Code>'file'</Code>
-          </td>
-          <td>Available modes of the component.</td>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed above the component.</td>
-        </tr>
-        <tr>
-          <td>buttonLabel: string</td>
-          <td></td>
-          <td>Text to be placed inside the button.</td>
-        </tr>
-        <tr>
-          <td>dropAreaLabel: string</td>
-          <td></td>
-          <td>
-            Text to be placed inside the drag and drop zone alongside the
-            button.
-          </td>
-        </tr>
-        <tr>
-          <td>helperText: string</td>
-          <td></td>
-          <td>Helper text to be placed above the component.</td>
-        </tr>
-        <tr>
-          <td>accept: string</td>
-          <td></td>
-          <td>
-            The file types that the component accepts. Its value must be one of
-            all the possible values of the HTML file input's accept attribute.
-            Please check the documentation{" "}
-            <DxcLink href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept">
-              here
-            </DxcLink>
-            .
-          </td>
-        </tr>
-        <tr>
-          <td>minSize: number</td>
-          <td></td>
-          <td>
-            The minimum file size (in bytes) allowed. If the size of the file
-            does not comply the minSize, the file will have an error.
-          </td>
-        </tr>
-        <tr>
-          <td>maxSize: number</td>
-          <td></td>
-          <td>
-            The maximum file size (in bytes) allowed. If the size of the file
-            does not comply the maxSize, the file will have an error.
-          </td>
-        </tr>
-        <tr>
-          <td>multiple: boolean</td>
-          <td>
-            <Code>true</Code>
-          </td>
-          <td>
-            If true, the component allows multiple file items and will show all
-            of them. If false, only one file will be shown, and if there is
-            already one file selected and a new one is chosen, it will be
-            replaced by the new selected one.
-          </td>
-        </tr>
-        <tr>
-          <td>value: object[]</td>
-          <td></td>
-          <td>
-            An array of files representing the selected files. Each file has the
-            following properties:
-            <ul>
-              <li>
-                <b>file: File</b>: Selected file.
-              </li>
-              <li>
-                <b>error: string</b>: Error of the file. If it is defined, it
-                will be shown and the file item will be mark as invalid.
-              </li>
-              <li>
-                <b>preview: string</b>: Preview of the file.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>showPreview: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, if the file is an image, a preview of it will be shown. If
-            not, an icon refering to the file type will be shown.
-          </td>
-        </tr>
-        <tr>
-          <td>disabled: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the component will be disabled.</td>
-        </tr>
-        <tr>
-          <td>callbackFile: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user selects or drops a file.
-            The list of files will be sent as a parameter. In this function, the
-            files can be updated or returned as they come. These files must be
-            passed to the value in order to be shown.
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>name: string</td>
+            <td></td>
+            <td>Name attribute.</td>
+          </tr>
+          <tr>
+            <td>mode: 'file' | 'filedrop' | 'dropzone'</td>
+            <td>
+              <Code>'file'</Code>
+            </td>
+            <td>Available modes of the component.</td>
+          </tr>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed above the component.</td>
+          </tr>
+          <tr>
+            <td>buttonLabel: string</td>
+            <td></td>
+            <td>Text to be placed inside the button.</td>
+          </tr>
+          <tr>
+            <td>dropAreaLabel: string</td>
+            <td></td>
+            <td>
+              Text to be placed inside the drag and drop zone alongside the
+              button.
+            </td>
+          </tr>
+          <tr>
+            <td>helperText: string</td>
+            <td></td>
+            <td>Helper text to be placed above the component.</td>
+          </tr>
+          <tr>
+            <td>accept: string</td>
+            <td></td>
+            <td>
+              The file types that the component accepts. Its value must be one
+              of all the possible values of the HTML file input's accept
+              attribute. Please check the documentation{" "}
+              <DxcLink href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept">
+                here
+              </DxcLink>
+              .
+            </td>
+          </tr>
+          <tr>
+            <td>minSize: number</td>
+            <td></td>
+            <td>
+              The minimum file size (in bytes) allowed. If the size of the file
+              does not comply the minSize, the file will have an error.
+            </td>
+          </tr>
+          <tr>
+            <td>maxSize: number</td>
+            <td></td>
+            <td>
+              The maximum file size (in bytes) allowed. If the size of the file
+              does not comply the maxSize, the file will have an error.
+            </td>
+          </tr>
+          <tr>
+            <td>multiple: boolean</td>
+            <td>
+              <Code>true</Code>
+            </td>
+            <td>
+              If true, the component allows multiple file items and will show
+              all of them. If false, only one file will be shown, and if there
+              is already one file selected and a new one is chosen, it will be
+              replaced by the new selected one.
+            </td>
+          </tr>
+          <tr>
+            <td>value: object[]</td>
+            <td></td>
+            <td>
+              An array of files representing the selected files. Each file has
+              the following properties:
+              <ul>
+                <li>
+                  <b>file: File</b>: Selected file.
+                </li>
+                <li>
+                  <b>error: string</b>: Error of the file. If it is defined, it
+                  will be shown and the file item will be mark as invalid.
+                </li>
+                <li>
+                  <b>preview: string</b>: Preview of the file.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>showPreview: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, if the file is an image, a preview of it will be shown.
+              If not, an icon refering to the file type will be shown.
+            </td>
+          </tr>
+          <tr>
+            <td>disabled: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the component will be disabled.</td>
+          </tr>
+          <tr>
+            <td>callbackFile: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user selects or drops a
+              file. The list of files will be sent as a parameter. In this
+              function, the files can be updated or returned as they come. These
+              files must be passed to the value in order to be shown.
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/footer/code/FooterCodePage.tsx
+++ b/website/screens/components/footer/code/FooterCodePage.tsx
@@ -13,91 +13,95 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>socialLinks: object[]</td>
-          <td>
-            <Code>[]</Code>
-          </td>
-          <td>
-            An array of objects representing the links that will be rendered as
-            icons at the top-right side of the footer. Each object has the
-            following properties:
-            <ul>
-              <li>
-                <b>logo</b>: Element or path used as the icon for the link.
-              </li>
-              <li>
-                <b>href</b>: URL of the page the link goes to.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>bottomLinks: object[]</td>
-          <td>
-            <Code>[]</Code>
-          </td>
-          <td>
-            An array of objects representing the links that will be rendered at
-            the bottom part of the footer. Each object has the following
-            properties:
-            <ul>
-              <li>
-                <b>text</b>: Text for the link.
-              </li>
-              <li>
-                <b>href</b>: URL of the page the link goes to.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>copyright: string</td>
-          <td></td>
-          <td>The text that will be displayed as copyright disclaimer.</td>
-        </tr>
-        <tr>
-          <td>children: node</td>
-          <td></td>
-          <td>
-            The center section of the footer. Can be used to render custom
-            content in this area.
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string</td>
-          <td></td>
-          <td>
-            Size of the top margin to be applied to the footer ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
-          </td>
-        </tr>
-        <tr>
-          <td>padding: string | object</td>
-          <td></td>
-          <td>
-            Size of the padding to be applied to the custom area of the
-            component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' |
-            'xlarge' | 'xxlarge'). You can pass an object with 'top', 'bottom',
-            'left' and 'right' properties in order to specify different padding
-            sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>
-            Value of the tabindex for all interactuable elements, except those
-            inside the custom area.
-          </td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>socialLinks: object[]</td>
+            <td>
+              <Code>[]</Code>
+            </td>
+            <td>
+              An array of objects representing the links that will be rendered
+              as icons at the top-right side of the footer. Each object has the
+              following properties:
+              <ul>
+                <li>
+                  <b>logo</b>: Element or path used as the icon for the link.
+                </li>
+                <li>
+                  <b>href</b>: URL of the page the link goes to.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>bottomLinks: object[]</td>
+            <td>
+              <Code>[]</Code>
+            </td>
+            <td>
+              An array of objects representing the links that will be rendered
+              at the bottom part of the footer. Each object has the following
+              properties:
+              <ul>
+                <li>
+                  <b>text</b>: Text for the link.
+                </li>
+                <li>
+                  <b>href</b>: URL of the page the link goes to.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>copyright: string</td>
+            <td></td>
+            <td>The text that will be displayed as copyright disclaimer.</td>
+          </tr>
+          <tr>
+            <td>children: node</td>
+            <td></td>
+            <td>
+              The center section of the footer. Can be used to render custom
+              content in this area.
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string</td>
+            <td></td>
+            <td>
+              Size of the top margin to be applied to the footer ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+            </td>
+          </tr>
+          <tr>
+            <td>padding: string | object</td>
+            <td></td>
+            <td>
+              Size of the padding to be applied to the custom area of the
+              component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' |
+              'xlarge' | 'xxlarge'). You can pass an object with 'top',
+              'bottom', 'left' and 'right' properties in order to specify
+              different padding sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>
+              Value of the tabindex for all interactuable elements, except those
+              inside the custom area.
+            </td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/header/code/HeaderCodePage.tsx
+++ b/website/screens/components/header/code/HeaderCodePage.tsx
@@ -21,75 +21,79 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>underlined: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            Wether a contrast line should appear at the bottom of the header.
-          </td>
-        </tr>
-        <tr>
-          <td>content: node</td>
-          <td></td>
-          <td>
-            Content showed in the header. Take into account that the component
-            applies styles for the first child in the content, so we recommend
-            the use of React.Fragment to be applied correctly. Otherwise, the
-            styles can be modified.
-          </td>
-        </tr>
-        <tr>
-          <td>responsiveContent: function</td>
-          <td></td>
-          <td>
-            Content showed in responsive version. It receives the close menu
-            handler that can be used to add that functionality when a element is
-            clicked.
-          </td>
-        </tr>
-        <tr>
-          <td>onClick: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user clicks the header logo.
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string</td>
-          <td></td>
-          <td>
-            Size of the bottom margin to be applied to the header ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
-          </td>
-        </tr>
-        <tr>
-          <td>padding: string | object</td>
-          <td></td>
-          <td>
-            Size of the padding to be applied to the custom area of the
-            component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' |
-            'xlarge' | 'xxlarge'). You can pass an object with 'top', 'bottom',
-            'left' and 'right' properties in order to specify different padding
-            sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>
-            Value of the tabindex for all interactuable elements, except those
-            inside the custom area.
-          </td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>underlined: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              Wether a contrast line should appear at the bottom of the header.
+            </td>
+          </tr>
+          <tr>
+            <td>content: node</td>
+            <td></td>
+            <td>
+              Content showed in the header. Take into account that the component
+              applies styles for the first child in the content, so we recommend
+              the use of React.Fragment to be applied correctly. Otherwise, the
+              styles can be modified.
+            </td>
+          </tr>
+          <tr>
+            <td>responsiveContent: function</td>
+            <td></td>
+            <td>
+              Content showed in responsive version. It receives the close menu
+              handler that can be used to add that functionality when a element
+              is clicked.
+            </td>
+          </tr>
+          <tr>
+            <td>onClick: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user clicks the header logo.
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string</td>
+            <td></td>
+            <td>
+              Size of the bottom margin to be applied to the header ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+            </td>
+          </tr>
+          <tr>
+            <td>padding: string | object</td>
+            <td></td>
+            <td>
+              Size of the padding to be applied to the custom area of the
+              component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' |
+              'xlarge' | 'xxlarge'). You can pass an object with 'top',
+              'bottom', 'left' and 'right' properties in order to specify
+              different padding sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>
+              Value of the tabindex for all interactuable elements, except those
+              inside the custom area.
+            </td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/heading/code/HeadingCodePage.tsx
+++ b/website/screens/components/heading/code/HeadingCodePage.tsx
@@ -13,49 +13,53 @@ const sections = [
     content: (
       <>
         <DxcTable>
-          <tr>
-            <th>Name</th>
-            <th>Default</th>
-            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-          </tr>
-          <tr>
-            <td>level: number</td>
-            <td>
-              <Code>1</Code>
-            </td>
-            <td>
-              Defines the heading level from 1 to 5. The styles of the heading
-              are applied according to the level. The html tag of the heading
-              will be the one specified in the 'as' prop. If 'as' is not
-              specified, the html tag of the heading is the one specified in the
-              'level' prop.
-            </td>
-          </tr>
-          <tr>
-            <td>text: string</td>
-            <td></td>
-            <td>Heading text.</td>
-          </tr>
-          <tr>
-            <td>as: 'h1' | 'h2' | 'h3' | 'h4'| 'h5' </td>
-            <td></td>
-            <td>Specifies the html tag of the heading.</td>
-          </tr>
-          <tr>
-            <td>weight: 'light' | 'normal' | 'bold'</td>
-            <td></td>
-            <td>Modifies the default weight of the heading.</td>
-          </tr>
-          <tr>
-            <td>margin: string | object</td>
-            <td></td>
-            <td>
-              Size of the margin to be applied to the component ('xxsmall' |
-              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
-              You can pass an object with 'top', 'bottom', 'left' and 'right'
-              properties in order to specify different margin sizes.
-            </td>
-          </tr>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Default</th>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>level: number</td>
+              <td>
+                <Code>1</Code>
+              </td>
+              <td>
+                Defines the heading level from 1 to 5. The styles of the heading
+                are applied according to the level. The html tag of the heading
+                will be the one specified in the 'as' prop. If 'as' is not
+                specified, the html tag of the heading is the one specified in
+                the 'level' prop.
+              </td>
+            </tr>
+            <tr>
+              <td>text: string</td>
+              <td></td>
+              <td>Heading text.</td>
+            </tr>
+            <tr>
+              <td>as: 'h1' | 'h2' | 'h3' | 'h4'| 'h5' </td>
+              <td></td>
+              <td>Specifies the html tag of the heading.</td>
+            </tr>
+            <tr>
+              <td>weight: 'light' | 'normal' | 'bold'</td>
+              <td></td>
+              <td>Modifies the default weight of the heading.</td>
+            </tr>
+            <tr>
+              <td>margin: string | object</td>
+              <td></td>
+              <td>
+                Size of the margin to be applied to the component ('xxsmall' |
+                'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+                You can pass an object with 'top', 'bottom', 'left' and 'right'
+                properties in order to specify different margin sizes.
+              </td>
+            </tr>
+          </tbody>
         </DxcTable>
       </>
     ),

--- a/website/screens/components/inline/code/InlineCodePage.tsx
+++ b/website/screens/components/inline/code/InlineCodePage.tsx
@@ -13,64 +13,68 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>alignX: 'start' | 'end' | 'center'</td>
-          <td>
-            <Code>'start'</Code>
-          </td>
-          <td>Alignment applied to children in the main axis.</td>
-        </tr>
-        <tr>
-          <td>alignY: 'start' | 'end' | 'center' | 'baseline' | 'stretch'</td>
-          <td>
-            <Code>'stretch'</Code>
-          </td>
-          <td>Alignment applied to children in the cross axis.</td>
-        </tr>
-        <tr>
-          <td>as: string | component</td>
-          <td>
-            <Code>'div'</Code>
-          </td>
-          <td>
-            Specifies the HTML tag or component that is rendered as the wrapper
-            element.
-          </td>
-        </tr>
-        <tr>
-          <td>divider: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, a divider is shown between each child.</td>
-        </tr>
-        <tr>
-          <td>
-            gutter: '0rem' | '0.125rem' | '0.25rem' | '0.5rem' | '0.75rem' |
-            '1rem' | '1.5rem' | '2rem' | '3rem' | '4rem' | '5rem'
-          </td>
-          <td>
-            <Code>'0rem'</Code>
-          </td>
-          <td>Space applied between each child.</td>
-        </tr>
-        <tr>
-          <td>reverse: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, it changes the direction of the inline to reverse.</td>
-        </tr>
-        <tr>
-          <td>children: node</td>
-          <td></td>
-          <td>Custom content inside the stack.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>alignX: 'start' | 'end' | 'center'</td>
+            <td>
+              <Code>'start'</Code>
+            </td>
+            <td>Alignment applied to children in the main axis.</td>
+          </tr>
+          <tr>
+            <td>alignY: 'start' | 'end' | 'center' | 'baseline' | 'stretch'</td>
+            <td>
+              <Code>'stretch'</Code>
+            </td>
+            <td>Alignment applied to children in the cross axis.</td>
+          </tr>
+          <tr>
+            <td>as: string | component</td>
+            <td>
+              <Code>'div'</Code>
+            </td>
+            <td>
+              Specifies the HTML tag or component that is rendered as the
+              wrapper element.
+            </td>
+          </tr>
+          <tr>
+            <td>divider: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, a divider is shown between each child.</td>
+          </tr>
+          <tr>
+            <td>
+              gutter: '0rem' | '0.125rem' | '0.25rem' | '0.5rem' | '0.75rem' |
+              '1rem' | '1.5rem' | '2rem' | '3rem' | '4rem' | '5rem'
+            </td>
+            <td>
+              <Code>'0rem'</Code>
+            </td>
+            <td>Space applied between each child.</td>
+          </tr>
+          <tr>
+            <td>reverse: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, it changes the direction of the inline to reverse.</td>
+          </tr>
+          <tr>
+            <td>children: node</td>
+            <td></td>
+            <td>Custom content inside the stack.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/nav-tabs/code/NavTabsCodePage.tsx
+++ b/website/screens/components/nav-tabs/code/NavTabsCodePage.tsx
@@ -23,28 +23,32 @@ const sections = [
         title: "DxcNavTabs",
         content: (
           <DxcTable>
-            <tr>
-              <th>Name</th>
-              <th>Default</th>
-              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-            </tr>
-            <tr>
-              <td>iconPosition: 'top' | 'left'</td>
-              <td>
-                <Code>'top'</Code>
-              </td>
-              <td>
-                Whether the icon should appear above or to the left of the
-                label.
-              </td>
-            </tr>
-            <tr>
-              <td>tabIndex: number</td>
-              <td>
-                <Code>0</Code>
-              </td>
-              <td>Value of the tabindex for each tab.</td>
-            </tr>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Default</th>
+                <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>iconPosition: 'top' | 'left'</td>
+                <td>
+                  <Code>'top'</Code>
+                </td>
+                <td>
+                  Whether the icon should appear above or to the left of the
+                  label.
+                </td>
+              </tr>
+              <tr>
+                <td>tabIndex: number</td>
+                <td>
+                  <Code>0</Code>
+                </td>
+                <td>Value of the tabindex for each tab.</td>
+              </tr>
+            </tbody>
           </DxcTable>
         ),
       },
@@ -52,56 +56,60 @@ const sections = [
         title: "DxcNavTabs.Tab",
         content: (
           <DxcTable>
-            <tr>
-              <th>Name</th>
-              <th>Default</th>
-              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-            </tr>
-            <tr>
-              <td>active: boolean</td>
-              <td>
-                <Code>false</Code>
-              </td>
-              <td>Whether the tab is active or not.</td>
-            </tr>
-            <tr>
-              <td>disabled: boolean</td>
-              <td>
-                <Code>false</Code>
-              </td>
-              <td>Whether the tab is disabled or not.</td>
-            </tr>
-            <tr>
-              <td>href: string</td>
-              <td></td>
-              <td>Page to be opened when the user clicks on the tab.</td>
-            </tr>
-            <tr>
-              <td>icon: node | string</td>
-              <td></td>
-              <td>
-                Element or path used as the icon that will be displayed in the
-                tab.
-              </td>
-            </tr>
-            <tr>
-              <td>notificationNumber: boolean | number</td>
-              <td>
-                <Code>false</Code>
-              </td>
-              <td>
-                If the value is 'true', an empty badge will appear. If it is
-                'false', no badge will appear. If a number is put it will be
-                shown as the label of the notification in the tab, taking into
-                account that if that number is greater than 99, it will appear
-                as '+99' in the badge.
-              </td>
-            </tr>
-            <tr>
-              <td>children: string</td>
-              <td></td>
-              <td>Content of the tab.</td>
-            </tr>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Default</th>
+                <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>active: boolean</td>
+                <td>
+                  <Code>false</Code>
+                </td>
+                <td>Whether the tab is active or not.</td>
+              </tr>
+              <tr>
+                <td>disabled: boolean</td>
+                <td>
+                  <Code>false</Code>
+                </td>
+                <td>Whether the tab is disabled or not.</td>
+              </tr>
+              <tr>
+                <td>href: string</td>
+                <td></td>
+                <td>Page to be opened when the user clicks on the tab.</td>
+              </tr>
+              <tr>
+                <td>icon: node | string</td>
+                <td></td>
+                <td>
+                  Element or path used as the icon that will be displayed in the
+                  tab.
+                </td>
+              </tr>
+              <tr>
+                <td>notificationNumber: boolean | number</td>
+                <td>
+                  <Code>false</Code>
+                </td>
+                <td>
+                  If the value is 'true', an empty badge will appear. If it is
+                  'false', no badge will appear. If a number is put it will be
+                  shown as the label of the notification in the tab, taking into
+                  account that if that number is greater than 99, it will appear
+                  as '+99' in the badge.
+                </td>
+              </tr>
+              <tr>
+                <td>children: string</td>
+                <td></td>
+                <td>Content of the tab.</td>
+              </tr>
+            </tbody>
           </DxcTable>
         ),
       },

--- a/website/screens/components/number-input/code/NumberInputCodePage.tsx
+++ b/website/screens/components/number-input/code/NumberInputCodePage.tsx
@@ -14,187 +14,193 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>defaultValue: string</td>
-          <td></td>
-          <td>
-            Initial value of the input element, only when it is uncontrolled.
-          </td>
-        </tr>
-        <tr>
-          <td>value: string</td>
-          <td></td>
-          <td>
-            Value of the input element. If undefined, the component will be
-            uncontrolled and the value will be managed internally by the
-            component.
-          </td>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed above the number.</td>
-        </tr>
-        <tr>
-          <td>name: string</td>
-          <td></td>
-          <td>Name attribute of the input element.</td>
-        </tr>
-        <tr>
-          <td>helperText: string</td>
-          <td></td>
-          <td>Helper text to be placed above the number.</td>
-        </tr>
-        <tr>
-          <td>placeholder: string</td>
-          <td></td>
-          <td>Text to be put as placeholder of the number.</td>
-        </tr>
-        <tr>
-          <td>disabled: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the component will be disabled.</td>
-        </tr>
-        <tr>
-          <td>optional: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, the number will be optional, showing{" "}
-            <Code>(Optional)</Code> next to the label. Otherwise, the field will
-            be considered required and an error will be passed as a parameter to
-            the OnBlur and onChange functions when it has not been filled.
-          </td>
-        </tr>
-        <tr>
-          <td>prefix: string</td>
-          <td></td>
-          <td>Prefix to be placed before the number value.</td>
-        </tr>
-        <tr>
-          <td>suffix: string</td>
-          <td></td>
-          <td>Suffix to be placed after the number value.</td>
-        </tr>
-        <tr>
-          <td>min: number</td>
-          <td></td>
-          <td>
-            Minimum value allowed by the number input. If the typed value by the
-            user is lower than min, the onBlur and onChange functions will be
-            called with the current value and an internal error informing that
-            the current value is not correct. If a valid state is reached, the
-            error parameter will not be defined in both events.
-          </td>
-        </tr>
-        <tr>
-          <td>max: number</td>
-          <td></td>
-          <td>
-            Maximum value allowed by the number input. If the typed value by the
-            user surpasses max, the onBlur and onChange functions will be called
-            with the current value and an internal error informing that the
-            current value is not correct. If a valid state is reached, the error
-            parameter will not be defined in both events.
-          </td>
-        </tr>
-        <tr>
-          <td>step: number</td>
-          <td></td>
-          <td>
-            The step interval to use when using the up and down arrows to adjust
-            the value.
-          </td>
-        </tr>
-        <tr>
-          <td>onChange: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user types within the input
-            element of the component. An object including the current value and
-            the error (if the value entered is not valid) will be passed to this
-            function. An example of this object is: {"{ "}
-            <Code>value: value, error: error</Code>
-            {" }"}. If there is no error, error will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>onBlur: function</td>
-          <td></td>
-          <td>
-            This function will be called when the input element loses the focus.
-            An object including the input value and the error (if the value
-            entered is not valid) will be passed to this function. An example of
-            this object is: {"{ "}
-            <Code>value: value, error: error</Code>
-            {" }"}. If there is no error, error will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>error: string</td>
-          <td></td>
-          <td>
-            If it is a defined value and also a truthy string, the component
-            will change its appearance, showing the error below the input
-            component. If the defined value is an empty string, it will reserve
-            a space below the component for a future error, but it would not
-            change its look. In case of being undefined or null, both the
-            appearance and the space for the error message would not be
-            modified.
-          </td>
-        </tr>
-        <tr>
-          <td>autocomplete: string</td>
-          <td>
-            <Code>'off'</Code>
-          </td>
-          <td>
-            HTML autocomplete attribute. Lets the user specify if any permission
-            the user agent has to provide automated assistance in filling out
-            the input value. Its value must be one of all the possible values of
-            the HTML autocomplete attribute: 'on', 'off', 'email', 'username',
-            'new-password', ...
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>size: string | object</td>
-          <td>
-            <Code>'medium'</Code>
-          </td>
-          <td>
-            Size of the component ('small' | 'medium' | 'large' | 'fillParent').
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex attribute.</td>
-        </tr>
-        <tr>
-          <td>ref: object</td>
-          <td></td>
-          <td>Reference to the component.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>defaultValue: string</td>
+            <td></td>
+            <td>
+              Initial value of the input element, only when it is uncontrolled.
+            </td>
+          </tr>
+          <tr>
+            <td>value: string</td>
+            <td></td>
+            <td>
+              Value of the input element. If undefined, the component will be
+              uncontrolled and the value will be managed internally by the
+              component.
+            </td>
+          </tr>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed above the number.</td>
+          </tr>
+          <tr>
+            <td>name: string</td>
+            <td></td>
+            <td>Name attribute of the input element.</td>
+          </tr>
+          <tr>
+            <td>helperText: string</td>
+            <td></td>
+            <td>Helper text to be placed above the number.</td>
+          </tr>
+          <tr>
+            <td>placeholder: string</td>
+            <td></td>
+            <td>Text to be put as placeholder of the number.</td>
+          </tr>
+          <tr>
+            <td>disabled: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the component will be disabled.</td>
+          </tr>
+          <tr>
+            <td>optional: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, the number will be optional, showing{" "}
+              <Code>(Optional)</Code> next to the label. Otherwise, the field
+              will be considered required and an error will be passed as a
+              parameter to the OnBlur and onChange functions when it has not
+              been filled.
+            </td>
+          </tr>
+          <tr>
+            <td>prefix: string</td>
+            <td></td>
+            <td>Prefix to be placed before the number value.</td>
+          </tr>
+          <tr>
+            <td>suffix: string</td>
+            <td></td>
+            <td>Suffix to be placed after the number value.</td>
+          </tr>
+          <tr>
+            <td>min: number</td>
+            <td></td>
+            <td>
+              Minimum value allowed by the number input. If the typed value by
+              the user is lower than min, the onBlur and onChange functions will
+              be called with the current value and an internal error informing
+              that the current value is not correct. If a valid state is
+              reached, the error parameter will not be defined in both events.
+            </td>
+          </tr>
+          <tr>
+            <td>max: number</td>
+            <td></td>
+            <td>
+              Maximum value allowed by the number input. If the typed value by
+              the user surpasses max, the onBlur and onChange functions will be
+              called with the current value and an internal error informing that
+              the current value is not correct. If a valid state is reached, the
+              error parameter will not be defined in both events.
+            </td>
+          </tr>
+          <tr>
+            <td>step: number</td>
+            <td></td>
+            <td>
+              The step interval to use when using the up and down arrows to
+              adjust the value.
+            </td>
+          </tr>
+          <tr>
+            <td>onChange: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user types within the input
+              element of the component. An object including the current value
+              and the error (if the value entered is not valid) will be passed
+              to this function. An example of this object is: {"{ "}
+              <Code>value: value, error: error</Code>
+              {" }"}. If there is no error, error will not be defined.
+            </td>
+          </tr>
+          <tr>
+            <td>onBlur: function</td>
+            <td></td>
+            <td>
+              This function will be called when the input element loses the
+              focus. An object including the input value and the error (if the
+              value entered is not valid) will be passed to this function. An
+              example of this object is: {"{ "}
+              <Code>value: value, error: error</Code>
+              {" }"}. If there is no error, error will not be defined.
+            </td>
+          </tr>
+          <tr>
+            <td>error: string</td>
+            <td></td>
+            <td>
+              If it is a defined value and also a truthy string, the component
+              will change its appearance, showing the error below the input
+              component. If the defined value is an empty string, it will
+              reserve a space below the component for a future error, but it
+              would not change its look. In case of being undefined or null,
+              both the appearance and the space for the error message would not
+              be modified.
+            </td>
+          </tr>
+          <tr>
+            <td>autocomplete: string</td>
+            <td>
+              <Code>'off'</Code>
+            </td>
+            <td>
+              HTML autocomplete attribute. Lets the user specify if any
+              permission the user agent has to provide automated assistance in
+              filling out the input value. Its value must be one of all the
+              possible values of the HTML autocomplete attribute: 'on', 'off',
+              'email', 'username', 'new-password', ...
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>size: string | object</td>
+            <td>
+              <Code>'medium'</Code>
+            </td>
+            <td>
+              Size of the component ('small' | 'medium' | 'large' |
+              'fillParent').
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex attribute.</td>
+          </tr>
+          <tr>
+            <td>ref: object</td>
+            <td></td>
+            <td>Reference to the component.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/paginator/code/PaginatorCodePage.tsx
+++ b/website/screens/components/paginator/code/PaginatorCodePage.tsx
@@ -12,77 +12,81 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>currentPage: number</td>
-          <td>
-            <Code>1</Code>
-          </td>
-          <td>Number of the current selected page.</td>
-        </tr>
-        <tr>
-          <td>itemsPerPage: number</td>
-          <td>
-            <Code>5</Code>
-          </td>
-          <td>Number of items per page.</td>
-        </tr>
-        <tr>
-          <td>itemsPerPageOptions: number[]</td>
-          <td>
-            <Code>[]</Code>
-          </td>
-          <td>
-            An array of numbers representing the items per page options. If
-            undefined, the select with items per page options will not be
-            displayed.
-          </td>
-        </tr>
-        <tr>
-          <td>itemsPerPageFunction: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user selects an item per page
-            option.
-          </td>
-        </tr>
-        <tr>
-          <td>totalItems: number</td>
-          <td>
-            <Code>1</Code>
-          </td>
-          <td>Total number of items in the pages.</td>
-        </tr>
-        <tr>
-          <td>showGoToPage: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, a select will be displayed with the page numbers to move
-            through them
-          </td>
-        </tr>
-        <tr>
-          <td>onPageChange: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user clicks on any of the
-            button to change pages. The page number will be passed as a
-            parameter to this function.
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>currentPage: number</td>
+            <td>
+              <Code>1</Code>
+            </td>
+            <td>Number of the current selected page.</td>
+          </tr>
+          <tr>
+            <td>itemsPerPage: number</td>
+            <td>
+              <Code>5</Code>
+            </td>
+            <td>Number of items per page.</td>
+          </tr>
+          <tr>
+            <td>itemsPerPageOptions: number[]</td>
+            <td>
+              <Code>[]</Code>
+            </td>
+            <td>
+              An array of numbers representing the items per page options. If
+              undefined, the select with items per page options will not be
+              displayed.
+            </td>
+          </tr>
+          <tr>
+            <td>itemsPerPageFunction: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user selects an item per
+              page option.
+            </td>
+          </tr>
+          <tr>
+            <td>totalItems: number</td>
+            <td>
+              <Code>1</Code>
+            </td>
+            <td>Total number of items in the pages.</td>
+          </tr>
+          <tr>
+            <td>showGoToPage: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, a select will be displayed with the page numbers to move
+              through them
+            </td>
+          </tr>
+          <tr>
+            <td>onPageChange: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user clicks on any of the
+              button to change pages. The page number will be passed as a
+              parameter to this function.
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/password-input/code/PasswordInputCodePage.tsx
+++ b/website/screens/components/password-input/code/PasswordInputCodePage.tsx
@@ -14,165 +14,172 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>value: string</td>
-          <td></td>
-          <td>
-            Value of the input element. If undefined, the component will be
-            uncontrolled and the value will be managed internally by the
-            component.
-          </td>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed above the password.</td>
-        </tr>
-        <tr>
-          <td>name: string</td>
-          <td></td>
-          <td>Name attribute of the input element.</td>
-        </tr>
-        <tr>
-          <td>helperText: string</td>
-          <td></td>
-          <td>Helper text to be placed above the password.</td>
-        </tr>
-        <tr>
-          <td>clearable: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, the password input will have an action to clear the entered
-            value.
-          </td>
-        </tr>
-        <tr>
-          <td>onChange: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user types within the input
-            element of the component. An object including the current value and
-            the error (if the value entered is not valid) will be passed to this
-            function. An example of this object is: {"{ "}
-            <Code>value: value, error: error</Code>
-            {" }"}. If there is no error, error will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>onBlur: function</td>
-          <td></td>
-          <td>
-            This function will be called when the input element loses the focus.
-            An object including the input value and the error (if the value
-            entered is not valid) will be passed to this function. An example of
-            this object is: {"{ "}
-            <Code>value: value, error: error</Code>
-            {" }"}. If there is no error, error will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>error: string</td>
-          <td></td>
-          <td>
-            If it is a defined value and also a truthy string, the component
-            will change its appearance, showing the error below the password
-            input component. If the defined value is an empty string, it will
-            reserve a space below the component for a future error, but it would
-            not change its look. In case of being undefined or null, both the
-            appearance and the space for the error message would not be
-            modified.
-          </td>
-        </tr>
-        <tr>
-          <td>pattern: string</td>
-          <td></td>
-          <td>
-            Regular expression that defines the valid format allowed by the
-            password input. This will be checked both when the input element
-            loses the focus and while typing within it. If the string entered
-            does not match the pattern, the onBlur and onChange functions will
-            be called with the current value and an internal error informing
-            that this value does not match the pattern. If the pattern is met,
-            the error parameter of both events will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>minLength: number</td>
-          <td></td>
-          <td>
-            Specifies the minimun length allowed by the input. This will be
-            checked both when the input element loses the focus and while typing
-            within it. If the string entered does not comply the minimum length,
-            the onBlur and onChange functions will be called with the current
-            value and an internal error informing that the value length does not
-            comply the specified range. If a valid length is reached, the error
-            parameter of both events will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>maxLength: number</td>
-          <td></td>
-          <td>
-            Specifies the maximum length allowed by the input. This will be
-            checked both when the input element loses the focus and while typing
-            within it. If the string entered does not comply the maximum length,
-            the onBlur and onChange functions will be called with the current
-            value and an internal error informing that the value length does not
-            comply the specified range. If a valid length is reached, the error
-            parameter of both events will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>autocomplete: string</td>
-          <td>
-            <Code>'off'</Code>
-          </td>
-          <td>
-            HTML autocomplete attribute. Lets the user specify if any permission
-            the user agent has to provide automated assistance in filling out
-            the input value. Its value must be one of all the possible values of
-            the HTML autocomplete attribute: 'on', 'off', 'email', 'username',
-            'new-password', ...
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>size: string</td>
-          <td>
-            <Code>'medium'</Code>
-          </td>
-          <td>
-            Size of the component ('small' | 'medium' | 'large' | 'fillParent').
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex attribute.</td>
-        </tr>
-        <tr>
-          <td>ref: object</td>
-          <td></td>
-          <td>Reference to the component.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>value: string</td>
+            <td></td>
+            <td>
+              Value of the input element. If undefined, the component will be
+              uncontrolled and the value will be managed internally by the
+              component.
+            </td>
+          </tr>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed above the password.</td>
+          </tr>
+          <tr>
+            <td>name: string</td>
+            <td></td>
+            <td>Name attribute of the input element.</td>
+          </tr>
+          <tr>
+            <td>helperText: string</td>
+            <td></td>
+            <td>Helper text to be placed above the password.</td>
+          </tr>
+          <tr>
+            <td>clearable: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, the password input will have an action to clear the
+              entered value.
+            </td>
+          </tr>
+          <tr>
+            <td>onChange: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user types within the input
+              element of the component. An object including the current value
+              and the error (if the value entered is not valid) will be passed
+              to this function. An example of this object is: {"{ "}
+              <Code>value: value, error: error</Code>
+              {" }"}. If there is no error, error will not be defined.
+            </td>
+          </tr>
+          <tr>
+            <td>onBlur: function</td>
+            <td></td>
+            <td>
+              This function will be called when the input element loses the
+              focus. An object including the input value and the error (if the
+              value entered is not valid) will be passed to this function. An
+              example of this object is: {"{ "}
+              <Code>value: value, error: error</Code>
+              {" }"}. If there is no error, error will not be defined.
+            </td>
+          </tr>
+          <tr>
+            <td>error: string</td>
+            <td></td>
+            <td>
+              If it is a defined value and also a truthy string, the component
+              will change its appearance, showing the error below the password
+              input component. If the defined value is an empty string, it will
+              reserve a space below the component for a future error, but it
+              would not change its look. In case of being undefined or null,
+              both the appearance and the space for the error message would not
+              be modified.
+            </td>
+          </tr>
+          <tr>
+            <td>pattern: string</td>
+            <td></td>
+            <td>
+              Regular expression that defines the valid format allowed by the
+              password input. This will be checked both when the input element
+              loses the focus and while typing within it. If the string entered
+              does not match the pattern, the onBlur and onChange functions will
+              be called with the current value and an internal error informing
+              that this value does not match the pattern. If the pattern is met,
+              the error parameter of both events will not be defined.
+            </td>
+          </tr>
+          <tr>
+            <td>minLength: number</td>
+            <td></td>
+            <td>
+              Specifies the minimun length allowed by the input. This will be
+              checked both when the input element loses the focus and while
+              typing within it. If the string entered does not comply the
+              minimum length, the onBlur and onChange functions will be called
+              with the current value and an internal error informing that the
+              value length does not comply the specified range. If a valid
+              length is reached, the error parameter of both events will not be
+              defined.
+            </td>
+          </tr>
+          <tr>
+            <td>maxLength: number</td>
+            <td></td>
+            <td>
+              Specifies the maximum length allowed by the input. This will be
+              checked both when the input element loses the focus and while
+              typing within it. If the string entered does not comply the
+              maximum length, the onBlur and onChange functions will be called
+              with the current value and an internal error informing that the
+              value length does not comply the specified range. If a valid
+              length is reached, the error parameter of both events will not be
+              defined.
+            </td>
+          </tr>
+          <tr>
+            <td>autocomplete: string</td>
+            <td>
+              <Code>'off'</Code>
+            </td>
+            <td>
+              HTML autocomplete attribute. Lets the user specify if any
+              permission the user agent has to provide automated assistance in
+              filling out the input value. Its value must be one of all the
+              possible values of the HTML autocomplete attribute: 'on', 'off',
+              'email', 'username', 'new-password', ...
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>size: string</td>
+            <td>
+              <Code>'medium'</Code>
+            </td>
+            <td>
+              Size of the component ('small' | 'medium' | 'large' |
+              'fillParent').
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex attribute.</td>
+          </tr>
+          <tr>
+            <td>ref: object</td>
+            <td></td>
+            <td>Reference to the component.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/progress-bar/code/ProgressBarCodePage.tsx
+++ b/website/screens/components/progress-bar/code/ProgressBarCodePage.tsx
@@ -13,53 +13,57 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed above the progress bar.</td>
-        </tr>
-        <tr>
-          <td>helperText: string</td>
-          <td></td>
-          <td>Helper text to be placed under the progress bar.</td>
-        </tr>
-        <tr>
-          <td>overlay: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the progress bar will be displayed as a modal.</td>
-        </tr>
-        <tr>
-          <td>value: number</td>
-          <td></td>
-          <td>
-            The value of the progress indicator. If it's received the component
-            is determinate otherwise is indeterminate.
-          </td>
-        </tr>
-        <tr>
-          <td>showValue: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the value is displayed above the progress bar.</td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed above the progress bar.</td>
+          </tr>
+          <tr>
+            <td>helperText: string</td>
+            <td></td>
+            <td>Helper text to be placed under the progress bar.</td>
+          </tr>
+          <tr>
+            <td>overlay: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the progress bar will be displayed as a modal.</td>
+          </tr>
+          <tr>
+            <td>value: number</td>
+            <td></td>
+            <td>
+              The value of the progress indicator. If it's received the
+              component is determinate otherwise is indeterminate.
+            </td>
+          </tr>
+          <tr>
+            <td>showValue: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the value is displayed above the progress bar.</td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/quick-nav/code/QuickNavCodePage.tsx
+++ b/website/screens/components/quick-nav/code/QuickNavCodePage.tsx
@@ -12,36 +12,40 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>title: string</td>
-          <td></td>
-          <td>Title of the quick nav component.</td>
-        </tr>
-        <tr>
-          <td>links: Link[]</td>
-          <td></td>
-          <td>
-            Links of the quick nav component. Each link has the following
-            properties:
-            <ul>
-              <li>
-                <b>label: string</b>: Text to be shown in the link. The content
-                must be wrapped with an id equals to the slugified label (in
-                lower case and the white spaces replaced by &#39;-&#39;) in
-                order to be able to navigate to the section that the label
-                references.
-              </li>
-              <li>
-                <b>links: Link[]</b>: Sublinks of the link.
-              </li>
-            </ul>
-          </td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>title: string</td>
+            <td></td>
+            <td>Title of the quick nav component.</td>
+          </tr>
+          <tr>
+            <td>links: Link[]</td>
+            <td></td>
+            <td>
+              Links of the quick nav component. Each link has the following
+              properties:
+              <ul>
+                <li>
+                  <b>label: string</b>: Text to be shown in the link. The
+                  content must be wrapped with an id equals to the slugified
+                  label (in lower case and the white spaces replaced by
+                  &#39;-&#39;) in order to be able to navigate to the section
+                  that the label references.
+                </li>
+                <li>
+                  <b>links: Link[]</b>: Sublinks of the link.
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/radio-group/code/RadioGroupCodePage.tsx
+++ b/website/screens/components/radio-group/code/RadioGroupCodePage.tsx
@@ -14,151 +14,156 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>defaultValue: string</td>
-          <td></td>
-          <td>
-            Initial value of the radio group, only when it is uncontrolled.
-          </td>
-        </tr>
-        <tr>
-          <td>value: string</td>
-          <td></td>
-          <td>
-            Value of the radio group. If undefined, the component will be
-            uncontrolled and the value will be managed internally by the
-            component.
-          </td>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed above the radio group.</td>
-        </tr>
-        <tr>
-          <td>name: string</td>
-          <td></td>
-          <td>
-            Name attribute of the input element. This attribute will allow users
-            to find the component's value during the submit event.
-          </td>
-        </tr>
-        <tr>
-          <td>options: Option[]</td>
-          <td></td>
-          <td>
-            An array of objects representing the selectable options. Each object
-            Option has the following properties:
-            <ul>
-              <li>
-                <b>label: string</b>: Label of the option placed next to the
-                radio input.
-              </li>
-              <li>
-                <b>value: string</b>: Value of the option. It should be unique
-                and not an empty string, which is reserved to the optional item
-                added by <i>optional</i> prop.
-              </li>
-              <li>
-                <b>disabled: boolean</b>: disables the option.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>helperText: string</td>
-          <td></td>
-          <td>Helper text to be placed above the radio group.</td>
-        </tr>
-        <tr>
-          <td>disabled: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the component will be disabled.</td>
-        </tr>
-        <tr>
-          <td>optional: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, the radio group will be optional, showing{" "}
-            <Code>(Optional)</Code> next to the label and adding a default last
-            option with an empty string as value. Otherwise, the field will be
-            considered required and an error will be passed as a parameter to
-            the OnBlur functions if an option wasn't selected.
-          </td>
-        </tr>
-        <tr>
-          <td>optionalItemLabel: string</td>
-          <td>
-            <Code>"N/A"</Code>
-          </td>
-          <td>Label of the optional radio input.</td>
-        </tr>
-        <tr>
-          <td>readonly: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the component will be marked as readonly.</td>
-        </tr>
-        <tr>
-          <td>stacking: "row" | "column"</td>
-          <td>
-            <Code>"column"</Code>
-          </td>
-          <td>Sets the orientation of the options within the radio group.</td>
-        </tr>
-        <tr>
-          <td>onChange: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user chooses an option. The
-            new value will be passed to this function.
-          </td>
-        </tr>
-        <tr>
-          <td>onBlur: function</td>
-          <td></td>
-          <td>
-            This function will be called when the radio group loses the focus.
-            An object including the value and the error will be passed to this
-            function. An example of this object is: {"{ "}
-            <Code>value: value, error: error</Code>
-            {" }"}. If there is no error, error will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>error: string</td>
-          <td></td>
-          <td>
-            If it is a defined value and also a truthy string, the component
-            will change its appearance, showing the error below the radio group.
-            If the defined value is an empty string, it will reserve a space
-            below the component for a future error, but it would not change its
-            look. In case of being undefined or null, both the appearance and
-            the space for the error message would not be modified.
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex attribute.</td>
-        </tr>
-        <tr>
-          <td>ref: object</td>
-          <td></td>
-          <td>Reference to the component.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>defaultValue: string</td>
+            <td></td>
+            <td>
+              Initial value of the radio group, only when it is uncontrolled.
+            </td>
+          </tr>
+          <tr>
+            <td>value: string</td>
+            <td></td>
+            <td>
+              Value of the radio group. If undefined, the component will be
+              uncontrolled and the value will be managed internally by the
+              component.
+            </td>
+          </tr>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed above the radio group.</td>
+          </tr>
+          <tr>
+            <td>name: string</td>
+            <td></td>
+            <td>
+              Name attribute of the input element. This attribute will allow
+              users to find the component's value during the submit event.
+            </td>
+          </tr>
+          <tr>
+            <td>options: Option[]</td>
+            <td></td>
+            <td>
+              An array of objects representing the selectable options. Each
+              object Option has the following properties:
+              <ul>
+                <li>
+                  <b>label: string</b>: Label of the option placed next to the
+                  radio input.
+                </li>
+                <li>
+                  <b>value: string</b>: Value of the option. It should be unique
+                  and not an empty string, which is reserved to the optional
+                  item added by <i>optional</i> prop.
+                </li>
+                <li>
+                  <b>disabled: boolean</b>: disables the option.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>helperText: string</td>
+            <td></td>
+            <td>Helper text to be placed above the radio group.</td>
+          </tr>
+          <tr>
+            <td>disabled: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the component will be disabled.</td>
+          </tr>
+          <tr>
+            <td>optional: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, the radio group will be optional, showing{" "}
+              <Code>(Optional)</Code> next to the label and adding a default
+              last option with an empty string as value. Otherwise, the field
+              will be considered required and an error will be passed as a
+              parameter to the OnBlur functions if an option wasn't selected.
+            </td>
+          </tr>
+          <tr>
+            <td>optionalItemLabel: string</td>
+            <td>
+              <Code>"N/A"</Code>
+            </td>
+            <td>Label of the optional radio input.</td>
+          </tr>
+          <tr>
+            <td>readonly: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the component will be marked as readonly.</td>
+          </tr>
+          <tr>
+            <td>stacking: "row" | "column"</td>
+            <td>
+              <Code>"column"</Code>
+            </td>
+            <td>Sets the orientation of the options within the radio group.</td>
+          </tr>
+          <tr>
+            <td>onChange: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user chooses an option. The
+              new value will be passed to this function.
+            </td>
+          </tr>
+          <tr>
+            <td>onBlur: function</td>
+            <td></td>
+            <td>
+              This function will be called when the radio group loses the focus.
+              An object including the value and the error will be passed to this
+              function. An example of this object is: {"{ "}
+              <Code>value: value, error: error</Code>
+              {" }"}. If there is no error, error will not be defined.
+            </td>
+          </tr>
+          <tr>
+            <td>error: string</td>
+            <td></td>
+            <td>
+              If it is a defined value and also a truthy string, the component
+              will change its appearance, showing the error below the radio
+              group. If the defined value is an empty string, it will reserve a
+              space below the component for a future error, but it would not
+              change its look. In case of being undefined or null, both the
+              appearance and the space for the error message would not be
+              modified.
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex attribute.</td>
+          </tr>
+          <tr>
+            <td>ref: object</td>
+            <td></td>
+            <td>Reference to the component.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/resultset-table/code/ResultsetTableCodePage.tsx
+++ b/website/screens/components/resultset-table/code/ResultsetTableCodePage.tsx
@@ -13,100 +13,106 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>columns: object[]</td>
-          <td>
-            <Code>[]</Code>
-          </td>
-          <td>
-            An array of objects representing the columns of the table. Each
-            object has the following properties:
-            <ul>
-              <li>
-                <b>displayValue</b>: Column display value.
-              </li>
-              <li>
-                <b>isSortable</b>: Boolean value to indicate whether the column
-                is sortable or not.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>rows: object[]</td>
-          <td>
-            <Code>[]</Code>
-          </td>
-          <td>
-            An array of objects representing the rows of the table, you will
-            have as many objects as columns in the table. Each object has the
-            following properties:
-            <ul>
-              <li>
-                <b>displayValue</b>: Value to be displayed in the cell.
-              </li>
-              <li>
-                <b>sortValue</b>: Value to be used when sorting the table by
-                that column. If not indicated displayValue will be used for
-                sorting.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>showGoToPage: boolean</td>
-          <td>
-            <Code>true</Code>
-          </td>
-          <td>
-            If true, a select component for navigation between pages will be
-            displayed.
-          </td>
-        </tr>
-        <tr>
-          <td>itemsPerPage: number</td>
-          <td>
-            <Code>5</Code>
-          </td>
-          <td>Number of items per page.</td>
-        </tr>
-        <tr>
-          <td>itemsPerPageOptions: number[]</td>
-          <td>
-            <Code>[]</Code>
-          </td>
-          <td>An array of numbers representing the items per page options.</td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex attribute given to the sortable icon.</td>
-        </tr>
-        <tr>
-          <td>itemsPerPageFunction: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user selects an item per page
-            option. The value selected will be passed as a parameter.
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>columns: object[]</td>
+            <td>
+              <Code>[]</Code>
+            </td>
+            <td>
+              An array of objects representing the columns of the table. Each
+              object has the following properties:
+              <ul>
+                <li>
+                  <b>displayValue</b>: Column display value.
+                </li>
+                <li>
+                  <b>isSortable</b>: Boolean value to indicate whether the
+                  column is sortable or not.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>rows: object[]</td>
+            <td>
+              <Code>[]</Code>
+            </td>
+            <td>
+              An array of objects representing the rows of the table, you will
+              have as many objects as columns in the table. Each object has the
+              following properties:
+              <ul>
+                <li>
+                  <b>displayValue</b>: Value to be displayed in the cell.
+                </li>
+                <li>
+                  <b>sortValue</b>: Value to be used when sorting the table by
+                  that column. If not indicated displayValue will be used for
+                  sorting.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>showGoToPage: boolean</td>
+            <td>
+              <Code>true</Code>
+            </td>
+            <td>
+              If true, a select component for navigation between pages will be
+              displayed.
+            </td>
+          </tr>
+          <tr>
+            <td>itemsPerPage: number</td>
+            <td>
+              <Code>5</Code>
+            </td>
+            <td>Number of items per page.</td>
+          </tr>
+          <tr>
+            <td>itemsPerPageOptions: number[]</td>
+            <td>
+              <Code>[]</Code>
+            </td>
+            <td>
+              An array of numbers representing the items per page options.
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex attribute given to the sortable icon.</td>
+          </tr>
+          <tr>
+            <td>itemsPerPageFunction: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user selects an item per
+              page option. The value selected will be passed as a parameter.
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/slider/code/SliderCodePage.tsx
+++ b/website/screens/components/slider/code/SliderCodePage.tsx
@@ -14,150 +14,155 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>defaultValue: number</td>
-          <td></td>
-          <td>Initial value of the slider, only when it is uncontrolled.</td>
-        </tr>
-        <tr>
-          <td>value: number</td>
-          <td></td>
-          <td>
-            The selected value. If undefined, the component will be uncontrolled
-            and the value will be managed internally by the component.
-          </td>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed above the slider.</td>
-        </tr>
-        <tr>
-          <td>name: string</td>
-          <td></td>
-          <td>Name attribute of the input element.</td>
-        </tr>
-        <tr>
-          <td>helperText: string</td>
-          <td></td>
-          <td>Helper text to be placed above the slider.</td>
-        </tr>
-        <tr>
-          <td>minValue: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>The minimum value available for selection.</td>
-        </tr>
-        <tr>
-          <td>maxValue: number</td>
-          <td>
-            <Code>100</Code>
-          </td>
-          <td>The maximum value available for selection.</td>
-        </tr>
-        <tr>
-          <td>step: number</td>
-          <td>
-            <Code>1</Code>
-          </td>
-          <td>The step interval between values available for selection.</td>
-        </tr>
-        <tr>
-          <td>showLimitsValues: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            Whether the min/max value labels should be displayed next to the
-            slider.
-          </td>
-        </tr>
-        <tr>
-          <td>showInput: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            Whether the input element for displaying/controlling the slider
-            value should be displayed next to the slider.
-          </td>
-        </tr>
-        <tr>
-          <td>disabled: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the component will be disabled.</td>
-        </tr>
-        <tr>
-          <td>marks: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>Whether the marks between each step should be shown or not.</td>
-        </tr>
-        <tr>
-          <td>onChange: function</td>
-          <td></td>
-          <td>
-            This function will be called when the slider changes its value, as
-            it&#39;s being dragged. The new value will be passed as a parameter
-            when this function is executed.
-          </td>
-        </tr>
-        <tr>
-          <td>onDragEnd: function</td>
-          <td></td>
-          <td>
-            This function will be called when the slider changes its value, but
-            only when the thumb is released. The new value will be passed as a
-            parameter when this function is executed.
-          </td>
-        </tr>
-        <tr>
-          <td>labelFormatCallback: function</td>
-          <td></td>
-          <td>
-            This function will be used to format the labels displayed next to
-            the slider. The value will be passed as parameter and the function
-            must return the formatted value.
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component (&#39;xxsmall&#39;
-            | &#39;xsmall&#39; | &#39;small&#39; | &#39;medium&#39; |
-            &#39;large&#39; | &#39;xlarge&#39; | &#39;xxlarge&#39;). You can
-            pass an object with &#39;top&#39;, &#39;bottom&#39;, &#39;left&#39;
-            and &#39;right&#39; properties in order to specify different margin
-            sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>size: string</td>
-          <td>
-            <Code>&#39;fillParent&#39;</Code>
-          </td>
-          <td>
-            Size of the component (&#39;medium&#39; | &#39;large&#39; |
-            &#39;fillParent&#39;).
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex attribute.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>defaultValue: number</td>
+            <td></td>
+            <td>Initial value of the slider, only when it is uncontrolled.</td>
+          </tr>
+          <tr>
+            <td>value: number</td>
+            <td></td>
+            <td>
+              The selected value. If undefined, the component will be
+              uncontrolled and the value will be managed internally by the
+              component.
+            </td>
+          </tr>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed above the slider.</td>
+          </tr>
+          <tr>
+            <td>name: string</td>
+            <td></td>
+            <td>Name attribute of the input element.</td>
+          </tr>
+          <tr>
+            <td>helperText: string</td>
+            <td></td>
+            <td>Helper text to be placed above the slider.</td>
+          </tr>
+          <tr>
+            <td>minValue: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>The minimum value available for selection.</td>
+          </tr>
+          <tr>
+            <td>maxValue: number</td>
+            <td>
+              <Code>100</Code>
+            </td>
+            <td>The maximum value available for selection.</td>
+          </tr>
+          <tr>
+            <td>step: number</td>
+            <td>
+              <Code>1</Code>
+            </td>
+            <td>The step interval between values available for selection.</td>
+          </tr>
+          <tr>
+            <td>showLimitsValues: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              Whether the min/max value labels should be displayed next to the
+              slider.
+            </td>
+          </tr>
+          <tr>
+            <td>showInput: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              Whether the input element for displaying/controlling the slider
+              value should be displayed next to the slider.
+            </td>
+          </tr>
+          <tr>
+            <td>disabled: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the component will be disabled.</td>
+          </tr>
+          <tr>
+            <td>marks: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>Whether the marks between each step should be shown or not.</td>
+          </tr>
+          <tr>
+            <td>onChange: function</td>
+            <td></td>
+            <td>
+              This function will be called when the slider changes its value, as
+              it&#39;s being dragged. The new value will be passed as a
+              parameter when this function is executed.
+            </td>
+          </tr>
+          <tr>
+            <td>onDragEnd: function</td>
+            <td></td>
+            <td>
+              This function will be called when the slider changes its value,
+              but only when the thumb is released. The new value will be passed
+              as a parameter when this function is executed.
+            </td>
+          </tr>
+          <tr>
+            <td>labelFormatCallback: function</td>
+            <td></td>
+            <td>
+              This function will be used to format the labels displayed next to
+              the slider. The value will be passed as parameter and the function
+              must return the formatted value.
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component
+              (&#39;xxsmall&#39; | &#39;xsmall&#39; | &#39;small&#39; |
+              &#39;medium&#39; | &#39;large&#39; | &#39;xlarge&#39; |
+              &#39;xxlarge&#39;). You can pass an object with &#39;top&#39;,
+              &#39;bottom&#39;, &#39;left&#39; and &#39;right&#39; properties in
+              order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>size: string</td>
+            <td>
+              <Code>&#39;fillParent&#39;</Code>
+            </td>
+            <td>
+              Size of the component (&#39;medium&#39; | &#39;large&#39; |
+              &#39;fillParent&#39;).
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex attribute.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/spinner/code/SpinnerCodePage.tsx
+++ b/website/screens/components/spinner/code/SpinnerCodePage.tsx
@@ -13,48 +13,52 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed inside the spinner.</td>
-        </tr>
-        <tr>
-          <td>mode: 'large' | 'small' | 'overlay' </td>
-          <td>
-            <Code>'large'</Code>
-          </td>
-          <td>The spinner can have overlay or small or large size. </td>
-        </tr>
-        <tr>
-          <td>value: number</td>
-          <td></td>
-          <td>
-            The value of the progress indicator. If it's received the component
-            is determinate, otherwise is indeterminate.
-          </td>
-        </tr>
-        <tr>
-          <td>showValue: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the value is displayed inside the spinner.</td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed inside the spinner.</td>
+          </tr>
+          <tr>
+            <td>mode: 'large' | 'small' | 'overlay' </td>
+            <td>
+              <Code>'large'</Code>
+            </td>
+            <td>The spinner can have overlay or small or large size. </td>
+          </tr>
+          <tr>
+            <td>value: number</td>
+            <td></td>
+            <td>
+              The value of the progress indicator. If it's received the
+              component is determinate, otherwise is indeterminate.
+            </td>
+          </tr>
+          <tr>
+            <td>showValue: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the value is displayed inside the spinner.</td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/switch/code/SwitchCodePage.tsx
+++ b/website/screens/components/switch/code/SwitchCodePage.tsx
@@ -13,105 +13,109 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>defaultChecked: boolean</td>
-          <td></td>
-          <td>Initial state of the switch, only when it is uncontrolled.</td>
-        </tr>
-        <tr>
-          <td>checked: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, the component is checked. If undefined, the component will
-            be uncontrolled and the checked attribute will be managed internally
-            by the component.
-          </td>
-        </tr>
-        <tr>
-          <td>value: string</td>
-          <td></td>
-          <td>
-            Will be passed to the value attribute of the html input element.
-            When inside a form, this value will be only submitted if the switch
-            is checked.
-          </td>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed next to the switch.</td>
-        </tr>
-        <tr>
-          <td>labelPosition: 'before' | 'after'</td>
-          <td>
-            <Code>'before'</Code>
-          </td>
-          <td>Whether the label should appear after or before the switch.</td>
-        </tr>
-        <tr>
-          <td>name: string</td>
-          <td></td>
-          <td>Name attribute of the input element.</td>
-        </tr>
-        <tr>
-          <td>disabled: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the component will be disabled.</td>
-        </tr>
-        <tr>
-          <td>optional: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, the component will display <Code>(Optional)</Code> next to
-            the label.
-          </td>
-        </tr>
-        <tr>
-          <td>onChange: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user clicks the switch. The
-            new value of the checked attribute will be passed as a parameter.
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>size: string</td>
-          <td>
-            <Code>'fitContent'</Code>
-          </td>
-          <td>
-            Size of the component ('small' | 'medium' | 'large' | 'fillParent' |
-            'fitContent').
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>defaultChecked: boolean</td>
+            <td></td>
+            <td>Initial state of the switch, only when it is uncontrolled.</td>
+          </tr>
+          <tr>
+            <td>checked: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, the component is checked. If undefined, the component
+              will be uncontrolled and the checked attribute will be managed
+              internally by the component.
+            </td>
+          </tr>
+          <tr>
+            <td>value: string</td>
+            <td></td>
+            <td>
+              Will be passed to the value attribute of the html input element.
+              When inside a form, this value will be only submitted if the
+              switch is checked.
+            </td>
+          </tr>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed next to the switch.</td>
+          </tr>
+          <tr>
+            <td>labelPosition: 'before' | 'after'</td>
+            <td>
+              <Code>'before'</Code>
+            </td>
+            <td>Whether the label should appear after or before the switch.</td>
+          </tr>
+          <tr>
+            <td>name: string</td>
+            <td></td>
+            <td>Name attribute of the input element.</td>
+          </tr>
+          <tr>
+            <td>disabled: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the component will be disabled.</td>
+          </tr>
+          <tr>
+            <td>optional: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, the component will display <Code>(Optional)</Code> next
+              to the label.
+            </td>
+          </tr>
+          <tr>
+            <td>onChange: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user clicks the switch. The
+              new value of the checked attribute will be passed as a parameter.
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>size: string</td>
+            <td>
+              <Code>'fitContent'</Code>
+            </td>
+            <td>
+              Size of the component ('small' | 'medium' | 'large' | 'fillParent'
+              | 'fitContent').
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/switch/specs/SwitchSpecsPage.tsx
+++ b/website/screens/components/switch/specs/SwitchSpecsPage.tsx
@@ -394,7 +394,6 @@ const sections = [
         title: "Margin",
         content: (
           <>
-            {" "}
             <DxcTable>
               <thead>
                 <tr>

--- a/website/screens/components/table/code/TableCodePage.tsx
+++ b/website/screens/components/table/code/TableCodePage.tsx
@@ -11,29 +11,33 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>children: node</td>
-          <td></td>
-          <td>
-            The center section of the table. Can be used to render custom
-            content in this area.
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>children: node</td>
+            <td></td>
+            <td>
+              The center section of the table. Can be used to render custom
+              content in this area.
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/table/code/examples/basicUsage.ts
+++ b/website/screens/components/table/code/examples/basicUsage.ts
@@ -4,26 +4,30 @@ const code = `() => {
   return (
     <DxcInset space="2rem">
       <DxcTable>
-        <tr>
-          <th>header 1</th>
-          <th>header 2</th>
-          <th>header 3</th>
-        </tr>
-        <tr>
-          <td>cell 1</td>
-          <td>cell 2</td>
-          <td>cell 3</td>
-        </tr>
-        <tr>
-          <td>cell 4</td>
-          <td>cell 5</td>
-          <td>cell 6</td>
-        </tr>
-        <tr>
-          <td>cell 7</td>
-          <td>cell 8</td>
-          <td>Cell 9</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>header 1</th>
+            <th>header 2</th>
+            <th>header 3</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>cell 1</td>
+            <td>cell 2</td>
+            <td>cell 3</td>
+          </tr>
+          <tr>
+            <td>cell 4</td>
+            <td>cell 5</td>
+            <td>cell 6</td>
+          </tr>
+          <tr>
+            <td>cell 7</td>
+            <td>cell 8</td>
+            <td>Cell 9</td>
+          </tr>
+        </tbody>
       </DxcTable>
     </DxcInset>
   );

--- a/website/screens/components/tabs/code/TabsCodePage.tsx
+++ b/website/screens/components/tabs/code/TabsCodePage.tsx
@@ -14,95 +14,99 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>tabs: object[]</td>
-          <td></td>
-          <td>
-            An array of objects representing the tabs. Each of them has the
-            following properties:
-            <ul>
-              <li>
-                <b>label</b>: Tab label.
-              </li>
-              <li>
-                <b>icon</b>: Element or path used as the icon that will be
-                displayed in the tab.
-              </li>
-              <li>
-                <b>isDisabled</b>: Whether the tab is disabled or not.
-              </li>
-              <li>
-                <b>notificationNumber</b>: It can have boolean type or number
-                type. If the value is 'true', an empty badge will appear. If it
-                is 'false', no badge will appear. If a number is put it will be
-                shown as the label of the notification in the tab, taking into
-                account that if that number is greater than 99, it will appear
-                as '+99' in the badge.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>iconPosition: 'top' | 'left'</td>
-          <td>
-            <Code>'top'</Code>
-          </td>
-          <td>
-            Whether the icon should appear above or to the left of the label.
-          </td>
-        </tr>
-        <tr>
-          <td>defaultActiveTabIndex: number</td>
-          <td></td>
-          <td>Initially active tab, only when it is uncontrolled.</td>
-        </tr>
-        <tr>
-          <td>activeTabIndex: number</td>
-          <td></td>
-          <td>
-            The index of the active tab. If undefined, the component will be
-            uncontrolled and the active tab will be managed internally by the
-            component.
-          </td>
-        </tr>
-        <tr>
-          <td>onTabClick: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user clicks on a tab. The
-            index of the clicked tab will be passed as a parameter.
-          </td>
-        </tr>
-        <tr>
-          <td>onTabHover: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user hovers a tab.The index of
-            the hovered tab will be passed as a parameter.
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex for each tab.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>tabs: object[]</td>
+            <td></td>
+            <td>
+              An array of objects representing the tabs. Each of them has the
+              following properties:
+              <ul>
+                <li>
+                  <b>label</b>: Tab label.
+                </li>
+                <li>
+                  <b>icon</b>: Element or path used as the icon that will be
+                  displayed in the tab.
+                </li>
+                <li>
+                  <b>isDisabled</b>: Whether the tab is disabled or not.
+                </li>
+                <li>
+                  <b>notificationNumber</b>: It can have boolean type or number
+                  type. If the value is 'true', an empty badge will appear. If
+                  it is 'false', no badge will appear. If a number is put it
+                  will be shown as the label of the notification in the tab,
+                  taking into account that if that number is greater than 99, it
+                  will appear as '+99' in the badge.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>iconPosition: 'top' | 'left'</td>
+            <td>
+              <Code>'top'</Code>
+            </td>
+            <td>
+              Whether the icon should appear above or to the left of the label.
+            </td>
+          </tr>
+          <tr>
+            <td>defaultActiveTabIndex: number</td>
+            <td></td>
+            <td>Initially active tab, only when it is uncontrolled.</td>
+          </tr>
+          <tr>
+            <td>activeTabIndex: number</td>
+            <td></td>
+            <td>
+              The index of the active tab. If undefined, the component will be
+              uncontrolled and the active tab will be managed internally by the
+              component.
+            </td>
+          </tr>
+          <tr>
+            <td>onTabClick: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user clicks on a tab. The
+              index of the clicked tab will be passed as a parameter.
+            </td>
+          </tr>
+          <tr>
+            <td>onTabHover: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user hovers a tab.The index
+              of the hovered tab will be passed as a parameter.
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex for each tab.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/tag/code/TagCodePage.tsx
+++ b/website/screens/components/tag/code/TagCodePage.tsx
@@ -13,89 +13,93 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed next inside the tag.</td>
-        </tr>
-        <tr>
-          <td>labelPosition: 'before' | 'after'</td>
-          <td>
-            <Code>'after'</Code>
-          </td>
-          <td>Whether the label should appear after or before the icon.</td>
-        </tr>
-        <tr>
-          <td>icon: node | string</td>
-          <td></td>
-          <td>
-            Element or path used as the icon that will be placed next to the
-            label.
-          </td>
-        </tr>
-        <tr>
-          <td>iconBgColor: string</td>
-          <td>
-            <Code>'#5f249f'</Code>
-          </td>
-          <td>Background color of the icon section of the tag.</td>
-        </tr>
-        <tr>
-          <td>linkHref: string</td>
-          <td></td>
-          <td>
-            If defined, the tag will be displayed as an anchor, using this prop
-            as "href". Component will show some visual feedback on hover.
-          </td>
-        </tr>
-        <tr>
-          <td>newWindow: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the page is opened in a new browser tab.</td>
-        </tr>
-        <tr>
-          <td>onClick: function</td>
-          <td></td>
-          <td>
-            If defined, the tag will be displayed as a button. This function
-            will be called when the user clicks the tag. Component will show
-            some visual feedback on hover.
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>size: string</td>
-          <td>
-            <Code>'fitContent'</Code>
-          </td>
-          <td>
-            Size of the component ('small' | 'medium' | 'large' | 'fillParent' |
-            'fitContent').
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex attribute.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed next inside the tag.</td>
+          </tr>
+          <tr>
+            <td>labelPosition: 'before' | 'after'</td>
+            <td>
+              <Code>'after'</Code>
+            </td>
+            <td>Whether the label should appear after or before the icon.</td>
+          </tr>
+          <tr>
+            <td>icon: node | string</td>
+            <td></td>
+            <td>
+              Element or path used as the icon that will be placed next to the
+              label.
+            </td>
+          </tr>
+          <tr>
+            <td>iconBgColor: string</td>
+            <td>
+              <Code>'#5f249f'</Code>
+            </td>
+            <td>Background color of the icon section of the tag.</td>
+          </tr>
+          <tr>
+            <td>linkHref: string</td>
+            <td></td>
+            <td>
+              If defined, the tag will be displayed as an anchor, using this
+              prop as "href". Component will show some visual feedback on hover.
+            </td>
+          </tr>
+          <tr>
+            <td>newWindow: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the page is opened in a new browser tab.</td>
+          </tr>
+          <tr>
+            <td>onClick: function</td>
+            <td></td>
+            <td>
+              If defined, the tag will be displayed as a button. This function
+              will be called when the user clicks the tag. Component will show
+              some visual feedback on hover.
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>size: string</td>
+            <td>
+              <Code>'fitContent'</Code>
+            </td>
+            <td>
+              Size of the component ('small' | 'medium' | 'large' | 'fillParent'
+              | 'fitContent').
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex attribute.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/tag/specs/TagSpecsPage.tsx
+++ b/website/screens/components/tag/specs/TagSpecsPage.tsx
@@ -64,7 +64,6 @@ const sections = [
         title: "Color",
         content: (
           <>
-            {" "}
             <DxcTable>
               <thead>
                 <tr>

--- a/website/screens/components/text-input/code/TextInputCodePage.tsx
+++ b/website/screens/components/text-input/code/TextInputCodePage.tsx
@@ -16,241 +16,251 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>defaultValue: string</td>
-          <td></td>
-          <td>Initial value of the input, only when it is uncontrolled.</td>
-        </tr>
-        <tr>
-          <td>value: string</td>
-          <td> </td>
-          <td>
-            Value of the input. If undefined, the component will be uncontrolled
-            and the value will be managed internally by the component.
-          </td>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>
-            Text to be placed above the input. This label will be used as the
-            aria-label attribute of the list of suggestions.
-          </td>
-        </tr>
-        <tr>
-          <td>name: string</td>
-          <td></td>
-          <td>Name attribute of the input element.</td>
-        </tr>
-        <tr>
-          <td>helperText: string</td>
-          <td></td>
-          <td>Helper text to be placed above the input.</td>
-        </tr>
-        <tr>
-          <td>placeholder: string</td>
-          <td></td>
-          <td>Text to be put as placeholder of the input.</td>
-        </tr>
-        <tr>
-          <td>action: object</td>
-          <td></td>
-          <td>
-            Action to be shown in the input. This is an object composed of an
-            onClick function and an icon, being the latter either an inline svg
-            or a URL to the image. An example of this object is: {"{ "}
-            <Code>
-              onClick: function, icon: string | svgIcon, title: string
-            </Code>
-            {" }"}.
-          </td>
-        </tr>
-        <tr>
-          <td>clearable: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, the input will have an action to clear the entered value.
-          </td>
-        </tr>
-        <tr>
-          <td>disabled: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the component will be disabled.</td>
-        </tr>
-        <tr>
-          <td>optional: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, the input will be optional, showing <Code>(Optional)</Code>{" "}
-            next to the label. Otherwise, the field will be considered required
-            and an error will be passed as a parameter to the OnBlur and
-            onChange functions when it has not been filled.
-          </td>
-        </tr>
-        <tr>
-          <td>prefix: string</td>
-          <td></td>
-          <td>Prefix to be placed before the input value.</td>
-        </tr>
-        <tr>
-          <td>suffix: string</td>
-          <td></td>
-          <td>Suffix to be placed after the input value.</td>
-        </tr>
-        <tr>
-          <td>onChange: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user types within the input
-            element of the component. An object including the current value and
-            the error (if the value entered is not valid) will be passed to this
-            function. An example of this object is: {"{ "}
-            <Code>value: value, error: error</Code>
-            {" }"}. If there is no error, error will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>onBlur: function</td>
-          <td></td>
-          <td>
-            This function will be called when the input element loses the focus.
-            An object including the input value and the error (if the value
-            entered is not valid) will be passed to this function. An example of
-            this object is: {"{ "}
-            <Code>value: value, error: error</Code>
-            {" }"}. If there is no error, error will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>error: string</td>
-          <td></td>
-          <td>
-            If it is a defined value and also a truthy string, the component
-            will change its appearance, showing the error below the input
-            component. If the defined value is an empty string, it will reserve
-            a space below the component for a future error, but it would not
-            change its look. In case of being undefined or null, both the
-            appearance and the space for the error message would not be
-            modified.
-          </td>
-        </tr>
-        <tr>
-          <td>suggestions: Array | function</td>
-          <td></td>
-          <td>
-            These are the options to be displayed as suggestions. It can be
-            either an array or a function:
-            <ul>
-              <li>
-                <b>Array</b>: Array of options that will be filtered by the
-                component.
-              </li>
-              <li>
-                <b>Function</b>: This function will be called when the user
-                changes the value, we will send as a parameter the new value;
-                apart from that this function should return one promise on which
-                we should make 'then' to get the suggestions filtered.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>pattern: string</td>
-          <td></td>
-          <td>
-            Regular expression that defines the valid format allowed by the
-            input. This will be checked both when the input element loses the
-            focus and while typing within it. If the string entered does not
-            match the pattern, the onBlur and onChange functions will be called
-            with the current value and an internal error informing that this
-            value does not match the pattern. If the pattern is met, the error
-            parameter of both events will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>minLength: number</td>
-          <td></td>
-          <td>
-            Specifies the minimun length allowed by the input. This will be
-            checked both when the input element loses the focus and while typing
-            within it. If the string entered does not comply the minimum length,
-            the onBlur and onChange functions will be called with the current
-            value and an internal error informing that the value length does not
-            comply the specified range. If a valid length is reached, the error
-            parameter of both events will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>maxLength: number</td>
-          <td></td>
-          <td>
-            Specifies the maximum length allowed by the input. This will be
-            checked both when the input element loses the focus and while typing
-            within it. If the string entered does not comply the maximum length,
-            the onBlur and onChange functions will be called with the current
-            value and an internal error informing that the value length does not
-            comply the specified range. If a valid length is reached, the error
-            parameter of both events will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>autocomplete: string</td>
-          <td>
-            <Code>'off'</Code>
-          </td>
-          <td>
-            HTML autocomplete attribute. Lets the user specify if any permission
-            the user agent has to provide automated assistance in filling out
-            the input value. Its value must be one of all the possible values of
-            the HTML autocomplete attribute. Please check the documentation{" "}
-            <DxcLink href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete">
-              here
-            </DxcLink>
-            .
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>size: string</td>
-          <td>
-            <Code>'medium'</Code>
-          </td>
-          <td>
-            Size of the component ('small' | 'medium' | 'large' | 'fillParent').
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex attribute.</td>
-        </tr>
-        <tr>
-          <td>ref: object</td>
-          <td></td>
-          <td>Reference to the component.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>defaultValue: string</td>
+            <td></td>
+            <td>Initial value of the input, only when it is uncontrolled.</td>
+          </tr>
+          <tr>
+            <td>value: string</td>
+            <td> </td>
+            <td>
+              Value of the input. If undefined, the component will be
+              uncontrolled and the value will be managed internally by the
+              component.
+            </td>
+          </tr>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>
+              Text to be placed above the input. This label will be used as the
+              aria-label attribute of the list of suggestions.
+            </td>
+          </tr>
+          <tr>
+            <td>name: string</td>
+            <td></td>
+            <td>Name attribute of the input element.</td>
+          </tr>
+          <tr>
+            <td>helperText: string</td>
+            <td></td>
+            <td>Helper text to be placed above the input.</td>
+          </tr>
+          <tr>
+            <td>placeholder: string</td>
+            <td></td>
+            <td>Text to be put as placeholder of the input.</td>
+          </tr>
+          <tr>
+            <td>action: object</td>
+            <td></td>
+            <td>
+              Action to be shown in the input. This is an object composed of an
+              onClick function and an icon, being the latter either an inline
+              svg or a URL to the image. An example of this object is: {"{ "}
+              <Code>
+                onClick: function, icon: string | svgIcon, title: string
+              </Code>
+              {" }"}.
+            </td>
+          </tr>
+          <tr>
+            <td>clearable: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, the input will have an action to clear the entered value.
+            </td>
+          </tr>
+          <tr>
+            <td>disabled: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the component will be disabled.</td>
+          </tr>
+          <tr>
+            <td>optional: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, the input will be optional, showing{" "}
+              <Code>(Optional)</Code> next to the label. Otherwise, the field
+              will be considered required and an error will be passed as a
+              parameter to the OnBlur and onChange functions when it has not
+              been filled.
+            </td>
+          </tr>
+          <tr>
+            <td>prefix: string</td>
+            <td></td>
+            <td>Prefix to be placed before the input value.</td>
+          </tr>
+          <tr>
+            <td>suffix: string</td>
+            <td></td>
+            <td>Suffix to be placed after the input value.</td>
+          </tr>
+          <tr>
+            <td>onChange: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user types within the input
+              element of the component. An object including the current value
+              and the error (if the value entered is not valid) will be passed
+              to this function. An example of this object is: {"{ "}
+              <Code>value: value, error: error</Code>
+              {" }"}. If there is no error, error will not be defined.
+            </td>
+          </tr>
+          <tr>
+            <td>onBlur: function</td>
+            <td></td>
+            <td>
+              This function will be called when the input element loses the
+              focus. An object including the input value and the error (if the
+              value entered is not valid) will be passed to this function. An
+              example of this object is: {"{ "}
+              <Code>value: value, error: error</Code>
+              {" }"}. If there is no error, error will not be defined.
+            </td>
+          </tr>
+          <tr>
+            <td>error: string</td>
+            <td></td>
+            <td>
+              If it is a defined value and also a truthy string, the component
+              will change its appearance, showing the error below the input
+              component. If the defined value is an empty string, it will
+              reserve a space below the component for a future error, but it
+              would not change its look. In case of being undefined or null,
+              both the appearance and the space for the error message would not
+              be modified.
+            </td>
+          </tr>
+          <tr>
+            <td>suggestions: Array | function</td>
+            <td></td>
+            <td>
+              These are the options to be displayed as suggestions. It can be
+              either an array or a function:
+              <ul>
+                <li>
+                  <b>Array</b>: Array of options that will be filtered by the
+                  component.
+                </li>
+                <li>
+                  <b>Function</b>: This function will be called when the user
+                  changes the value, we will send as a parameter the new value;
+                  apart from that this function should return one promise on
+                  which we should make 'then' to get the suggestions filtered.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>pattern: string</td>
+            <td></td>
+            <td>
+              Regular expression that defines the valid format allowed by the
+              input. This will be checked both when the input element loses the
+              focus and while typing within it. If the string entered does not
+              match the pattern, the onBlur and onChange functions will be
+              called with the current value and an internal error informing that
+              this value does not match the pattern. If the pattern is met, the
+              error parameter of both events will not be defined.
+            </td>
+          </tr>
+          <tr>
+            <td>minLength: number</td>
+            <td></td>
+            <td>
+              Specifies the minimun length allowed by the input. This will be
+              checked both when the input element loses the focus and while
+              typing within it. If the string entered does not comply the
+              minimum length, the onBlur and onChange functions will be called
+              with the current value and an internal error informing that the
+              value length does not comply the specified range. If a valid
+              length is reached, the error parameter of both events will not be
+              defined.
+            </td>
+          </tr>
+          <tr>
+            <td>maxLength: number</td>
+            <td></td>
+            <td>
+              Specifies the maximum length allowed by the input. This will be
+              checked both when the input element loses the focus and while
+              typing within it. If the string entered does not comply the
+              maximum length, the onBlur and onChange functions will be called
+              with the current value and an internal error informing that the
+              value length does not comply the specified range. If a valid
+              length is reached, the error parameter of both events will not be
+              defined.
+            </td>
+          </tr>
+          <tr>
+            <td>autocomplete: string</td>
+            <td>
+              <Code>'off'</Code>
+            </td>
+            <td>
+              HTML autocomplete attribute. Lets the user specify if any
+              permission the user agent has to provide automated assistance in
+              filling out the input value. Its value must be one of all the
+              possible values of the HTML autocomplete attribute. Please check
+              the documentation{" "}
+              <DxcLink href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete">
+                here
+              </DxcLink>
+              .
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>size: string</td>
+            <td>
+              <Code>'medium'</Code>
+            </td>
+            <td>
+              Size of the component ('small' | 'medium' | 'large' |
+              'fillParent').
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex attribute.</td>
+          </tr>
+          <tr>
+            <td>ref: object</td>
+            <td></td>
+            <td>Reference to the component.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/textarea/code/TextareaCodePage.tsx
+++ b/website/screens/components/textarea/code/TextareaCodePage.tsx
@@ -14,212 +14,222 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>defaultValue: string</td>
-          <td></td>
-          <td>Initial value of the textarea, only when it is uncontrolled.</td>
-        </tr>
-        <tr>
-          <td>value: string</td>
-          <td></td>
-          <td>
-            Value of the textarea. If undefined, the component will be
-            uncontrolled and the value will be managed internally.
-          </td>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed above the textarea.</td>
-        </tr>
-        <tr>
-          <td>name: string</td>
-          <td></td>
-          <td>Name attribute of the textarea element.</td>
-        </tr>
-        <tr>
-          <td>helperText: string</td>
-          <td></td>
-          <td>Helper text to be placed above the textarea.</td>
-        </tr>
-        <tr>
-          <td>placeholder: string</td>
-          <td></td>
-          <td>Text to be put as placeholder of the textarea.</td>
-        </tr>
-        <tr>
-          <td>disabled: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the component will be disabled.</td>
-        </tr>
-        <tr>
-          <td>optional: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, the textarea will be optional, showing{" "}
-            <Code>(Optional)</Code> next to the label. Otherwise, the field will
-            be considered required and an error will be passed as a parameter to
-            the OnBlur and onChange functions when it has not been filled.
-          </td>
-        </tr>
-        <tr>
-          <td>verticalGrow: 'auto' | 'manual' | 'none'</td>
-          <td>
-            <Code>'auto'</Code>
-          </td>
-          <td>
-            Defines the textarea's ability to resize vertically. It can be:
-            <ul>
-              <li>
-                <b>'auto'</b>: The textarea grows or shrinks automatically in
-                order to fit the content.
-              </li>
-              <li>
-                <b>'manual'</b>: The height of the textarea is enabled to be
-                manually modified.
-              </li>
-              <li>
-                <b>'none'</b>: The textarea has a fixed height and can't be
-                modified.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>rows: number</td>
-          <td>
-            <Code>4</Code>
-          </td>
-          <td>Number of rows of the textarea.</td>
-        </tr>
-        <tr>
-          <td>onChange: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user types within the
-            textarea. An object including the current value and the error (if
-            the value entered is not valid) will be passed to this function. An
-            example of this object is: {"{ "}
-            <Code>value: value, error: error</Code>
-            {" }"}. If there is no error, error will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>onBlur: function</td>
-          <td></td>
-          <td>
-            This function will be called when the textarea loses the focus. An
-            object including the textarea value and the error (if the value
-            entered is not valid) will be passed to this function. An example of
-            this object is: {"{ "}
-            <Code>value: value, error: error</Code>
-            {" }"}. If there is no error, error will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>error: string</td>
-          <td></td>
-          <td>
-            If it is a defined value and also a truthy string, the component
-            will change its appearance, showing the error below the textarea. If
-            the defined value is an empty string, it will reserve a space below
-            the component for a future error, but it would not change its look.
-            In case of being undefined or null, both the appearance and the
-            space for the error message would not be modified.
-          </td>
-        </tr>
-        <tr>
-          <td>pattern: string</td>
-          <td></td>
-          <td>
-            Regular expression that defines the valid format allowed by the
-            textarea. This will be checked both when the textarea loses the
-            focus and while typing within it. If the string entered does not
-            match the pattern, the onBlur and onChange functions will be called
-            with the current value and an internal error informing that this
-            value does not match the pattern. If the pattern is met, the error
-            parameter of both events will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>minLength: number</td>
-          <td></td>
-          <td>
-            Specifies the minimun length allowed by the textarea. This will be
-            checked both when the input element loses the focus and while typing
-            within it. If the string entered does not comply the minimum length,
-            the onBlur and onChange functions will be called with the current
-            value and an internal error informing that the value length does not
-            comply the specified range. If a valid length is reached, the error
-            parameter of both events will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>maxLength: number</td>
-          <td></td>
-          <td>
-            Specifies the maximum length allowed by the textarea. This will be
-            checked both when the input element loses the focus and while typing
-            within it. If the string entered does not comply the maximum length,
-            the onBlur and onChange functions will be called with the current
-            value and an internal error informing that the value length does not
-            comply the specified range. If a valid length is reached, the error
-            parameter of both events will not be defined.
-          </td>
-        </tr>
-        <tr>
-          <td>autocomplete: string</td>
-          <td>
-            <Code>'off'</Code>
-          </td>
-          <td>
-            HTML autocomplete attribute. Lets the user specify if any permission
-            the user agent has to provide automated assistance in filling out
-            the textarea value. Its value must be one of all the possible values
-            of the HTML autocomplete attribute: 'on', 'off', 'email',
-            'username', 'new-password', ...
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>size: string</td>
-          <td>
-            <Code>'medium'</Code>
-          </td>
-          <td>
-            Size of the component ('small' | 'medium' | 'large' | 'fillParent').
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex attribute.</td>
-        </tr>
-        <tr>
-          <td>ref: object</td>
-          <td></td>
-          <td>Reference to the component.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>defaultValue: string</td>
+            <td></td>
+            <td>
+              Initial value of the textarea, only when it is uncontrolled.
+            </td>
+          </tr>
+          <tr>
+            <td>value: string</td>
+            <td></td>
+            <td>
+              Value of the textarea. If undefined, the component will be
+              uncontrolled and the value will be managed internally.
+            </td>
+          </tr>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed above the textarea.</td>
+          </tr>
+          <tr>
+            <td>name: string</td>
+            <td></td>
+            <td>Name attribute of the textarea element.</td>
+          </tr>
+          <tr>
+            <td>helperText: string</td>
+            <td></td>
+            <td>Helper text to be placed above the textarea.</td>
+          </tr>
+          <tr>
+            <td>placeholder: string</td>
+            <td></td>
+            <td>Text to be put as placeholder of the textarea.</td>
+          </tr>
+          <tr>
+            <td>disabled: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the component will be disabled.</td>
+          </tr>
+          <tr>
+            <td>optional: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, the textarea will be optional, showing{" "}
+              <Code>(Optional)</Code> next to the label. Otherwise, the field
+              will be considered required and an error will be passed as a
+              parameter to the OnBlur and onChange functions when it has not
+              been filled.
+            </td>
+          </tr>
+          <tr>
+            <td>verticalGrow: 'auto' | 'manual' | 'none'</td>
+            <td>
+              <Code>'auto'</Code>
+            </td>
+            <td>
+              Defines the textarea's ability to resize vertically. It can be:
+              <ul>
+                <li>
+                  <b>'auto'</b>: The textarea grows or shrinks automatically in
+                  order to fit the content.
+                </li>
+                <li>
+                  <b>'manual'</b>: The height of the textarea is enabled to be
+                  manually modified.
+                </li>
+                <li>
+                  <b>'none'</b>: The textarea has a fixed height and can't be
+                  modified.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>rows: number</td>
+            <td>
+              <Code>4</Code>
+            </td>
+            <td>Number of rows of the textarea.</td>
+          </tr>
+          <tr>
+            <td>onChange: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user types within the
+              textarea. An object including the current value and the error (if
+              the value entered is not valid) will be passed to this function.
+              An example of this object is: {"{ "}
+              <Code>value: value, error: error</Code>
+              {" }"}. If there is no error, error will not be defined.
+            </td>
+          </tr>
+          <tr>
+            <td>onBlur: function</td>
+            <td></td>
+            <td>
+              This function will be called when the textarea loses the focus. An
+              object including the textarea value and the error (if the value
+              entered is not valid) will be passed to this function. An example
+              of this object is: {"{ "}
+              <Code>value: value, error: error</Code>
+              {" }"}. If there is no error, error will not be defined.
+            </td>
+          </tr>
+          <tr>
+            <td>error: string</td>
+            <td></td>
+            <td>
+              If it is a defined value and also a truthy string, the component
+              will change its appearance, showing the error below the textarea.
+              If the defined value is an empty string, it will reserve a space
+              below the component for a future error, but it would not change
+              its look. In case of being undefined or null, both the appearance
+              and the space for the error message would not be modified.
+            </td>
+          </tr>
+          <tr>
+            <td>pattern: string</td>
+            <td></td>
+            <td>
+              Regular expression that defines the valid format allowed by the
+              textarea. This will be checked both when the textarea loses the
+              focus and while typing within it. If the string entered does not
+              match the pattern, the onBlur and onChange functions will be
+              called with the current value and an internal error informing that
+              this value does not match the pattern. If the pattern is met, the
+              error parameter of both events will not be defined.
+            </td>
+          </tr>
+          <tr>
+            <td>minLength: number</td>
+            <td></td>
+            <td>
+              Specifies the minimun length allowed by the textarea. This will be
+              checked both when the input element loses the focus and while
+              typing within it. If the string entered does not comply the
+              minimum length, the onBlur and onChange functions will be called
+              with the current value and an internal error informing that the
+              value length does not comply the specified range. If a valid
+              length is reached, the error parameter of both events will not be
+              defined.
+            </td>
+          </tr>
+          <tr>
+            <td>maxLength: number</td>
+            <td></td>
+            <td>
+              Specifies the maximum length allowed by the textarea. This will be
+              checked both when the input element loses the focus and while
+              typing within it. If the string entered does not comply the
+              maximum length, the onBlur and onChange functions will be called
+              with the current value and an internal error informing that the
+              value length does not comply the specified range. If a valid
+              length is reached, the error parameter of both events will not be
+              defined.
+            </td>
+          </tr>
+          <tr>
+            <td>autocomplete: string</td>
+            <td>
+              <Code>'off'</Code>
+            </td>
+            <td>
+              HTML autocomplete attribute. Lets the user specify if any
+              permission the user agent has to provide automated assistance in
+              filling out the textarea value. Its value must be one of all the
+              possible values of the HTML autocomplete attribute: 'on', 'off',
+              'email', 'username', 'new-password', ...
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>size: string</td>
+            <td>
+              <Code>'medium'</Code>
+            </td>
+            <td>
+              Size of the component ('small' | 'medium' | 'large' |
+              'fillParent').
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex attribute.</td>
+          </tr>
+          <tr>
+            <td>ref: object</td>
+            <td></td>
+            <td>Reference to the component.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/toggle-group/code/ToggleGroupCodePage.tsx
+++ b/website/screens/components/toggle-group/code/ToggleGroupCodePage.tsx
@@ -14,104 +14,108 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>label: string</td>
-          <td></td>
-          <td>Text to be placed above the component.</td>
-        </tr>
-        <tr>
-          <td>helperText: string</td>
-          <td></td>
-          <td>Helper text to be placed above the component.</td>
-        </tr>
-        <tr>
-          <td>defaultValue: number | number[]</td>
-          <td></td>
-          <td>
-            The key(s) of the initially selected value(s), only when it is
-            uncontrolled.
-          </td>
-        </tr>
-        <tr>
-          <td>value: number | number[]</td>
-          <td></td>
-          <td>
-            The key(s) of the selected value(s). If the toggle group component
-            doesn't allow multiple selection, it must be one unique value. If
-            the component allows multiple selection, value must be an array. If
-            undefined, the component will be uncontrolled and the value will be
-            managed internally by the component.
-          </td>
-        </tr>
-        <tr>
-          <td>onChange: function</td>
-          <td></td>
-          <td>
-            This function will be called every time the selection changes. The
-            number with the key of the selected value will be passed as a
-            parameter to this function. If multiple selection is allowed, an
-            array of keys will be passed
-          </td>
-        </tr>
-        <tr>
-          <td>disabled: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>If true, the component will be disabled.</td>
-        </tr>
-        <tr>
-          <td>multiple: boolean</td>
-          <td>
-            <Code>false</Code>
-          </td>
-          <td>
-            If true, the toggle group will support multiple selection. In that
-            case, value must be an array of numbers with the keys of the
-            selected values.
-          </td>
-        </tr>
-        <tr>
-          <td>options: object[]</td>
-          <td></td>
-          <td>
-            An array of objects representing the selectable options. Each object
-            has the following properties:
-            <ul>
-              <li>
-                <b>value</b>: Number with the option inner value.
-              </li>
-              <li>
-                <b>label</b>: String with the option display value.
-              </li>
-              <li>
-                <b>icon</b>: Element or path used as the icon of an option.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>Value of the tabindex.</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>label: string</td>
+            <td></td>
+            <td>Text to be placed above the component.</td>
+          </tr>
+          <tr>
+            <td>helperText: string</td>
+            <td></td>
+            <td>Helper text to be placed above the component.</td>
+          </tr>
+          <tr>
+            <td>defaultValue: number | number[]</td>
+            <td></td>
+            <td>
+              The key(s) of the initially selected value(s), only when it is
+              uncontrolled.
+            </td>
+          </tr>
+          <tr>
+            <td>value: number | number[]</td>
+            <td></td>
+            <td>
+              The key(s) of the selected value(s). If the toggle group component
+              doesn't allow multiple selection, it must be one unique value. If
+              the component allows multiple selection, value must be an array.
+              If undefined, the component will be uncontrolled and the value
+              will be managed internally by the component.
+            </td>
+          </tr>
+          <tr>
+            <td>onChange: function</td>
+            <td></td>
+            <td>
+              This function will be called every time the selection changes. The
+              number with the key of the selected value will be passed as a
+              parameter to this function. If multiple selection is allowed, an
+              array of keys will be passed
+            </td>
+          </tr>
+          <tr>
+            <td>disabled: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>If true, the component will be disabled.</td>
+          </tr>
+          <tr>
+            <td>multiple: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>
+              If true, the toggle group will support multiple selection. In that
+              case, value must be an array of numbers with the keys of the
+              selected values.
+            </td>
+          </tr>
+          <tr>
+            <td>options: object[]</td>
+            <td></td>
+            <td>
+              An array of objects representing the selectable options. Each
+              object has the following properties:
+              <ul>
+                <li>
+                  <b>value</b>: Number with the option inner value.
+                </li>
+                <li>
+                  <b>label</b>: String with the option display value.
+                </li>
+                <li>
+                  <b>icon</b>: Element or path used as the icon of an option.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>Value of the tabindex.</td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/components/wizard/code/WizardCodePage.tsx
+++ b/website/screens/components/wizard/code/WizardCodePage.tsx
@@ -14,90 +14,94 @@ const sections = [
     title: "Props",
     content: (
       <DxcTable>
-        <tr>
-          <th>Name</th>
-          <th>Default</th>
-          <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-        </tr>
-        <tr>
-          <td>mode: 'horizontal' | 'vertical'</td>
-          <td>
-            <Code>'horizontal'</Code>
-          </td>
-          <td>The wizard can be showed in horizontal or vertical.</td>
-        </tr>
-        <tr>
-          <td>defaultCurrentStep: number</td>
-          <td></td>
-          <td>Initially selected step, only when it is uncontrolled.</td>
-        </tr>
-        <tr>
-          <td>currentStep: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>
-            Defines which step is marked as the current. The numeration starts
-            at 0. If undefined, the component will be uncontrolled and the step
-            will be managed internally by the component.
-          </td>
-        </tr>
-        <tr>
-          <td>onStepClick: function</td>
-          <td></td>
-          <td>
-            This function will be called when the user clicks a step. The step
-            number will be passed as a parameter.
-          </td>
-        </tr>
-        <tr>
-          <td>steps: object[]</td>
-          <td>
-            <Code>[]</Code>
-          </td>
-          <td>
-            An array of objects representing the steps. Each of them has the
-            following properties:
-            <ul>
-              <li>
-                <b>Label: string</b>: Step label.
-              </li>
-              <li>
-                <b>Description: string</b>: Description that will be placed next
-                to the step.
-              </li>
-              <li>
-                <b>Icon: string | SVGSVGElement</b>: Element or path used as the
-                icon displayed in the step.
-              </li>
-              <li>
-                <b>Disabled: boolean</b>: Whether the step is disabled or not.
-              </li>
-              <li>
-                <b>Valid: boolean</b>: Whether the step is valid or not.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>margin: string | object</td>
-          <td></td>
-          <td>
-            Size of the margin to be applied to the component ('xxsmall' |
-            'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). You
-            can pass an object with 'top', 'bottom', 'left' and 'right'
-            properties in order to specify different margin sizes.
-          </td>
-        </tr>
-        <tr>
-          <td>tabIndex: number</td>
-          <td>
-            <Code>0</Code>
-          </td>
-          <td>
-            Value of the tabindex attribute that is given to all the steps.
-          </td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Default</th>
+            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>mode: 'horizontal' | 'vertical'</td>
+            <td>
+              <Code>'horizontal'</Code>
+            </td>
+            <td>The wizard can be showed in horizontal or vertical.</td>
+          </tr>
+          <tr>
+            <td>defaultCurrentStep: number</td>
+            <td></td>
+            <td>Initially selected step, only when it is uncontrolled.</td>
+          </tr>
+          <tr>
+            <td>currentStep: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>
+              Defines which step is marked as the current. The numeration starts
+              at 0. If undefined, the component will be uncontrolled and the
+              step will be managed internally by the component.
+            </td>
+          </tr>
+          <tr>
+            <td>onStepClick: function</td>
+            <td></td>
+            <td>
+              This function will be called when the user clicks a step. The step
+              number will be passed as a parameter.
+            </td>
+          </tr>
+          <tr>
+            <td>steps: object[]</td>
+            <td>
+              <Code>[]</Code>
+            </td>
+            <td>
+              An array of objects representing the steps. Each of them has the
+              following properties:
+              <ul>
+                <li>
+                  <b>Label: string</b>: Step label.
+                </li>
+                <li>
+                  <b>Description: string</b>: Description that will be placed
+                  next to the step.
+                </li>
+                <li>
+                  <b>Icon: string | SVGSVGElement</b>: Element or path used as
+                  the icon displayed in the step.
+                </li>
+                <li>
+                  <b>Disabled: boolean</b>: Whether the step is disabled or not.
+                </li>
+                <li>
+                  <b>Valid: boolean</b>: Whether the step is valid or not.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>margin: string | object</td>
+            <td></td>
+            <td>
+              Size of the margin to be applied to the component ('xxsmall' |
+              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              You can pass an object with 'top', 'bottom', 'left' and 'right'
+              properties in order to specify different margin sizes.
+            </td>
+          </tr>
+          <tr>
+            <td>tabIndex: number</td>
+            <td>
+              <Code>0</Code>
+            </td>
+            <td>
+              Value of the tabindex attribute that is given to all the steps.
+            </td>
+          </tr>
+        </tbody>
       </DxcTable>
     ),
   },

--- a/website/screens/principles/themes/ThemesPage.tsx
+++ b/website/screens/principles/themes/ThemesPage.tsx
@@ -153,8 +153,10 @@ const sections = [
         content: (
           <DxcTable>
             <thead>
-              <th>Theme Input</th>
-              <th>Tokens (calculation)</th>
+              <tr>
+                <th>Theme Input</th>
+                <th>Tokens (calculation)</th>
+              </tr>
             </thead>
             <tbody>
               <tr>


### PR DESCRIPTION
Added `thead` and `tbody` to tables to avoid warning.
Added `key` to Accordion group to avoid warning.