### PR TITLE
Removed accordion warning about renaming material-ui components

### DIFF
--- a/lib/src/accordion/Accordion.tsx
+++ b/lib/src/accordion/Accordion.tsx
@@ -1,9 +1,9 @@
 // @ts-nocheck
 import React, { useState } from "react";
 import styled, { ThemeProvider } from "styled-components";
-import ExpansionPanel from "@material-ui/core/ExpansionPanel";
-import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
-import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import Accordion from "@material-ui/core/Accordion";
+import AccordionSummary from "@material-ui/core/AccordionSummary";
+import AccordionDetails from "@material-ui/core/AccordionActions";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import { getMargin } from "../common/utils.js";
 import { spaces } from "../common/variables.js";
@@ -39,12 +39,12 @@ const DxcAccordion = ({
   return (
     <ThemeProvider theme={colorsTheme.accordion}>
       <DXCAccordion padding={padding} margin={margin} disabled={disabled} icon={icon}>
-        <ExpansionPanel
+        <Accordion
           disabled={disabled}
           onChange={handlerAccordion}
           expanded={isExpanded != null ? isExpanded : innerIsExpanded}
         >
-          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />} tabIndex={disabled ? -1 : tabIndex}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />} tabIndex={disabled ? -1 : tabIndex}>
             <AccordionInfo disabled={disabled}>
               {icon && (
                 <IconContainer disabled={disabled}>
@@ -54,15 +54,15 @@ const DxcAccordion = ({
               <AccordionLabel>{label}</AccordionLabel>
             </AccordionInfo>
             {assistiveText && <AccordionAssistiveText disabled={disabled}>{assistiveText}</AccordionAssistiveText>}
-          </ExpansionPanelSummary>
-          <ExpansionPanelDetails>
+          </AccordionSummary>
+          <AccordionDetails>
             <AccordionContent disabled={disabled}>
               <BackgroundColorProvider color={colorsTheme.accordion.backgroundColor}>
                 {children}
               </BackgroundColorProvider>
             </AccordionContent>
-          </ExpansionPanelDetails>
-        </ExpansionPanel>
+          </AccordionDetails>
+        </Accordion>
       </DXCAccordion>
     </ThemeProvider>
   );

--- a/lib/src/accordion/Accordion.tsx
+++ b/lib/src/accordion/Accordion.tsx
@@ -99,15 +99,15 @@ const DXCAccordion = styled.div`
     &.Mui-expanded {
       border-radius: ${(props) => props.theme.borderRadius};
     }
-    &.MuiExpansionPanel-root {
+    &.MuiAccordion-root {
       display: flex;
       flex-direction: column;
       min-height: 48px;
     }
-    &.MuiExpansionPanel-rounded {
+    &.MuiAccordion-rounded {
       border-radius: ${(props) => props.theme.borderRadius};
     }
-    .MuiButtonBase-root.MuiExpansionPanelSummary-root {
+    .MuiButtonBase-root.MuiAccordionSummary-root {
       min-height: 48px;
       height: 48px;
 
@@ -140,7 +140,7 @@ const DXCAccordion = styled.div`
       &.MuiIconButton-root {
         height: auto;
       }
-      .MuiExpansionPanelSummary-content {
+      .MuiAccordionSummary-content {
         padding-top: ${(props) => props.theme.titleLabelPaddingTop};
         padding-bottom: ${(props) => props.theme.titleLabelPaddingBottom};
         padding-right: ${(props) => props.theme.titleLabelPaddingRight};
@@ -175,7 +175,7 @@ const DXCAccordion = styled.div`
       color: ${(props) => (props.disabled ? props.theme.disabledArrowColor : props.theme.arrowColor)};
     }
   }
-  .MuiExpansionPanelDetails-root {
+  .MuiAccordionDetails-root {
     padding: ${(props) => (props.padding && typeof props.padding !== "object" ? spaces[props.padding] : "0px")};
     padding-top: ${(props) =>
       props.padding && typeof props.padding === "object" && props.padding.top ? spaces[props.padding.top] : ""};


### PR DESCRIPTION
Renamed the material-ui components as indicated in the warning:
`ExpansionPanel` to `Accordion`.
`ExpansionPanelSummary` to `AccordionSummary`.
`ExpansionPanelDetails` to `AccordionDetails`.