### PR TITLE
New wrap prop in Stack component

### DIFF
--- a/lib/src/stack/Stack.stories.tsx
+++ b/lib/src/stack/Stack.stories.tsx
@@ -44,9 +44,17 @@ export const Chromatic = () => (
     </Container>
     <Title title="Wrap" theme="light" level={4} />
     <FlexContainer customHeight>
+      <DxcStack wrap>
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+      </DxcStack>
+    </FlexContainer>
+    <Title title="No wrap" theme="light" level={4} />
+    <FlexContainer customHeight>
       <DxcStack>
-        <Placeholder />
-        <Placeholder />
         <Placeholder />
         <Placeholder />
         <Placeholder />
@@ -88,7 +96,7 @@ export const Chromatic = () => (
     </Container>
     <Title title="AlignX with wrapped items" theme="light" level={4} />
     <FlexContainer customHeight>
-      <DxcStack alignX="center">
+      <DxcStack alignX="center" wrap>
         <Placeholder />
         <Placeholder paddingRight={60} />
         <Placeholder paddingLeft={20} />

--- a/lib/src/stack/Stack.tsx
+++ b/lib/src/stack/Stack.tsx
@@ -8,10 +8,11 @@ const DxcStack = ({
   divider = false,
   gutter = "0rem",
   reverse = false,
+  wrap = false,
   children,
 }: StackPropsType): JSX.Element => {
   return (
-    <Stack gutter={gutter} alignX={alignX} reverse={reverse} as={as} divider={divider}>
+    <Stack gutter={gutter} alignX={alignX} reverse={reverse} as={as} divider={divider} wrap={wrap}>
       {React.Children.map(children, (child, index) => {
         return (
           <>
@@ -33,10 +34,11 @@ const Divider = styled.div`
 const Stack = styled.div<StackPropsType>`
   display: flex;
   flex-wrap: wrap;
-  ${({ alignX, gutter, reverse, divider }) => `
+  ${({ alignX, gutter, reverse, divider, wrap }) => `
     flex-direction: ${reverse ? "column-reverse" : "column"};
     align-items: ${alignX === "start" || alignX === "end" ? `flex-${alignX}` : alignX};
     gap: ${divider ? `calc(${gutter}/2 - 1px)` : gutter};
+    flex-wrap: ${wrap ? "wrap" : "nowrap"};
   `}
   padding: 0px;
   margin: 0px;

--- a/lib/src/stack/types.tsx
+++ b/lib/src/stack/types.tsx
@@ -31,6 +31,10 @@ type Props = {
    */
   reverse?: boolean;
   /**
+   * Wrap the items if needed.
+   */
+   wrap?: boolean;
+  /**
    * Custom content inside the stack.
    */
   children: React.ReactNode[] | React.ReactNode;


### PR DESCRIPTION
Now, wrap functionality is optional and must be activated with `wrap` prop.