### PR TITLE
[Minor] New prop wrap for Inline component

### DIFF
--- a/lib/src/inline/Inline.stories.tsx
+++ b/lib/src/inline/Inline.stories.tsx
@@ -38,7 +38,7 @@ export const Chromatic = () => (
     </FlexContainer>
     <Title title="Wrap" theme="light" level={4} />
     <Container customWidth>
-      <DxcInline>
+      <DxcInline wrap>
         <Placeholder height="large" width="small" />
         <Placeholder height="large" width="medium" />
         <Placeholder height="medium" width="small" />
@@ -74,7 +74,7 @@ export const Chromatic = () => (
     </Container>
     <Title title="AlignY with wrapped items" theme="light" level={4} />
     <Container customWidth>
-      <DxcInline alignY="end">
+      <DxcInline alignY="end" wrap>
         <Placeholder height="large" width="small" />
         <Placeholder height="large" width="medium" />
         <Placeholder height="medium" width="small" />
@@ -122,7 +122,7 @@ export const Chromatic = () => (
     </Container>
     <Title title="AlignX with wrapped items" theme="light" level={4} />
     <Container customWidth>
-      <DxcInline alignX="center">
+      <DxcInline alignX="center" wrap>
         <Placeholder height="small" width="small" />
         <Placeholder height="large" width="medium" />
         <Placeholder height="medium" width="small" />
@@ -221,6 +221,23 @@ export const Chromatic = () => (
     <Title title="Reverse" theme="light" level={4} />
     <Container>
       <DxcInline reverse>
+        <Placeholder height="small" width="small">
+          1
+        </Placeholder>
+        <Placeholder height="medium" width="medium">
+          2
+        </Placeholder>
+        <Placeholder height="large" width="large">
+          3
+        </Placeholder>
+        <Placeholder height="small" width="large">
+          4
+        </Placeholder>
+      </DxcInline>
+    </Container>
+    <Title title="Wrapped and reversed children" theme="light" level={4} />
+    <Container customWidth>
+      <DxcInline reverse wrap>
         <Placeholder height="small" width="small">
           1
         </Placeholder>

--- a/lib/src/inline/Inline.stories.tsx
+++ b/lib/src/inline/Inline.stories.tsx
@@ -51,9 +51,24 @@ export const Chromatic = () => (
         <Placeholder height="large" width="small" />
         <Placeholder height="large" width="medium" />
         <Placeholder height="medium" width="small" />
-        <Placeholder height="large" width="medium" />
+        <Placeholder height="small" width="medium" />
+        <Placeholder height="large" width="small" />
+        <Placeholder height="medium" width="large" />
+        <Placeholder height="small" width="medium" />
       </DxcInline>
     </Container>
+    <Title title="Nowrap in a flex container (overflows)" theme="light" level={4} />
+    <FlexContainer customWidth>
+      <DxcInline>
+        <Placeholder height="large" width="small" />
+        <Placeholder height="large" width="medium" />
+        <Placeholder height="medium" width="small" />
+        <Placeholder height="small" width="medium" />
+        <Placeholder height="large" width="small" />
+        <Placeholder height="medium" width="large" />
+        <Placeholder height="small" width="medium" />
+      </DxcInline>
+    </FlexContainer>
     <Title title="AlignY = start" theme="light" level={4} />
     <Container>
       <DxcInline alignY="stretch">

--- a/lib/src/inline/Inline.stories.tsx
+++ b/lib/src/inline/Inline.stories.tsx
@@ -45,6 +45,15 @@ export const Chromatic = () => (
         <Placeholder height="large" width="medium" />
       </DxcInline>
     </Container>
+    <Title title="Nowrap (default)" theme="light" level={4} />
+    <Container customWidth>
+      <DxcInline>
+        <Placeholder height="large" width="small" />
+        <Placeholder height="large" width="medium" />
+        <Placeholder height="medium" width="small" />
+        <Placeholder height="large" width="medium" />
+      </DxcInline>
+    </Container>
     <Title title="AlignY = start" theme="light" level={4} />
     <Container>
       <DxcInline alignY="stretch">

--- a/lib/src/inline/Inline.tsx
+++ b/lib/src/inline/Inline.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import InlineProps from "./types";
 
 const DxcInline = ({
+  wrap = false,
   alignX = "start",
   alignY = "stretch",
   as = "div",
@@ -12,7 +13,7 @@ const DxcInline = ({
   children,
 }: InlineProps): JSX.Element => {
   return (
-    <Inline as={as} alignX={alignX} alignY={alignY} gutter={gutter} reverse={reverse} divider={divider}>
+    <Inline wrap={wrap} as={as} alignX={alignX} alignY={alignY} gutter={gutter} reverse={reverse} divider={divider}>
       {React.Children.map(children, (child, index) => {
         return (
           <>
@@ -27,7 +28,8 @@ const DxcInline = ({
 
 const Inline = styled.div<InlineProps>`
   display: flex;
-  ${({ alignX, alignY, gutter, reverse, divider }) => `
+  ${({ wrap, alignX, alignY, gutter, reverse, divider }) => `
+    flex-wrap: ${wrap ? "wrap" : "nowrap"};
     flex-direction: ${reverse ? "row-reverse" : "row"};
     align-items: stretch;
     justify-content: ${alignX === "start" || alignX === "end" ? `flex-${alignX}` : alignX};
@@ -37,7 +39,6 @@ const Inline = styled.div<InlineProps>`
       align-self: ${alignY === "start" || alignY === "end" ? `flex-${alignY}` : alignY};
     }
   `}
-  flex-wrap: wrap;
   padding: 0px;
   margin: 0px;
 `;

--- a/lib/src/inline/types.ts
+++ b/lib/src/inline/types.ts
@@ -1,5 +1,9 @@
 type Props = {
   /**
+   * Sets whether the children are forced onto one line or can wrap onto multiple lines.
+   */
+  wrap?: boolean;
+  /**
    * Alignment applied to children in the main axis.
    */
   alignX?: "start" | "end" | "center";

--- a/website/screens/components/inline/code/InlineCodePage.tsx
+++ b/website/screens/components/inline/code/InlineCodePage.tsx
@@ -22,6 +22,13 @@ const sections = [
         </thead>
         <tbody>
           <tr>
+            <td>wrap: boolean</td>
+            <td>
+              <Code>false</Code>
+            </td>
+            <td>Sets whether the children are forced onto one line or can wrap onto multiple lines.</td>
+          </tr>
+          <tr>
             <td>alignX: 'start' | 'end' | 'center'</td>
             <td>
               <Code>'start'</Code>


### PR DESCRIPTION
As we discussed, a new prop `wrap` for the Inline component, so the user can decide whether items should be wrapped onto one line or jump to a new one we they can be fitted in a single row.