### PR TITLE
Fix Sidenav poping in responsive mode

### DIFF
--- a/lib/src/layout/ApplicationLayout.tsx
+++ b/lib/src/layout/ApplicationLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useLayoutEffect, useRef } from "react";
 import DxcHeader from "../header/Header";
 import DxcFooter from "../footer/Footer";
 import DxcSidenav from "../sidenav/Sidenav";
@@ -74,17 +74,17 @@ const DxcApplicationLayout = ({
     setIsSidenavVisibleResponsive((isSidenavVisibleResponsive) => !isSidenavVisibleResponsive);
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     handleResize();
     window.addEventListener("resize", handleResize);
     return () => {
       window.removeEventListener("resize", handleResize);
     };
-  }, [setIsResponsive]);
+  }, []);
 
   useEffect(() => {
     !isResponsive && setIsSidenavVisibleResponsive(false);
-  }, [isResponsive, setIsSidenavVisibleResponsive]);
+  }, [isResponsive]);
 
   return (
     <ApplicationLayoutContainer


### PR DESCRIPTION
Sidenav tends to appear a fraction of a second when the new site is loaded in responsive mode since the beginning. A small code refactor to try to load the page with the sidenav collapsed since the first render and avoid its popping.