### PR TITLE
Working with any minor from React 18

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -13,8 +13,8 @@
   "main": "./main.js",
   "types": "./main.d.ts",
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.x",
+    "react-dom": "^18.x",
     "styled-components": "^5.0.1"
   },
   "dependencies": {
@@ -73,8 +73,8 @@
     "eslint-plugin-storybook": "^0.5.5",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^25.5.4",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.x",
+    "react-dom": "^18.x",
     "react-test-renderer": "^16.8.6",
     "storybook-addon-pseudo-states": "^1.0.0",
     "styled-components": "^5.0.1",


### PR DESCRIPTION
Before we had React 18.2.0 version, this forces the users to have this exact version as peer-dependency. Now, we allow the users to have any minor version that is part of React 18.