### PR TITLE
Change status to ready in several components

### DIFF
--- a/website/screens/components/bleed/BleedPageLayout.tsx
+++ b/website/screens/components/bleed/BleedPageLayout.tsx
@@ -10,7 +10,7 @@ const BleedPageHeading = ({ children }: { children: React.ReactNode }) => {
     <DxcFlex direction="column" gap="3rem">
       <PageHeading>
         <DxcFlex direction="column" gap="2rem">
-          <ComponentHeading name="Bleed" status="Experimental" />
+          <ComponentHeading name="Bleed" status="Ready" />
           <DxcParagraph>
             Bleed layout applies negative spacing scale to its child nodes.
           </DxcParagraph>

--- a/website/screens/components/bulleted-list/BulletedListPageLayout.tsx
+++ b/website/screens/components/bulleted-list/BulletedListPageLayout.tsx
@@ -1,10 +1,7 @@
 import PageHeading from "@/common/PageHeading";
-import {
-  DxcHeading,
-  DxcFlex,
-  DxcParagraph,
-} from "@dxc-technology/halstack-react";
+import { DxcFlex, DxcParagraph } from "@dxc-technology/halstack-react";
 import TabsPageHeading from "@/common/TabsPageLayout";
+import ComponentHeading from "@/common/ComponentHeading";
 
 const BulletedListPageHeading = ({
   children,
@@ -23,7 +20,7 @@ const BulletedListPageHeading = ({
     <DxcFlex direction="column" gap="3rem">
       <PageHeading>
         <DxcFlex direction="column" gap="2rem">
-          <DxcHeading level={1} text="Bulleted list" weight="bold"></DxcHeading>
+          <ComponentHeading name="Bulleted List" status="Ready" />
           <DxcParagraph>
             Bulleted list are used to display text items in a bulleted format.
           </DxcParagraph>

--- a/website/screens/components/flex/FlexPageLayout.tsx
+++ b/website/screens/components/flex/FlexPageLayout.tsx
@@ -10,7 +10,7 @@ const FlexPageHeading = ({ children }: { children: React.ReactNode }) => {
     <DxcFlex direction="column" gap="3rem">
       <PageHeading>
         <DxcFlex direction="column" gap="2rem">
-          <ComponentHeading name="Flex" status="Experimental" />
+          <ComponentHeading name="Flex" status="Ready" />
           <DxcParagraph>
             Flex allows users to build{" "}
             <DxcLink href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">

--- a/website/screens/components/inset/InsetPageLayout.tsx
+++ b/website/screens/components/inset/InsetPageLayout.tsx
@@ -10,7 +10,7 @@ const InsetPageHeading = ({ children }: { children: React.ReactNode }) => {
     <DxcFlex direction="column" gap="3rem">
       <PageHeading>
         <DxcFlex direction="column" gap="2rem">
-          <ComponentHeading name="Inset" status="Experimental" />
+          <ComponentHeading name="Inset" status="Ready" />
           <DxcParagraph>
             Inset layout applies positive spacing scale to its child nodes.
           </DxcParagraph>

--- a/website/screens/components/nav-tabs/NavTabsPageLayout.tsx
+++ b/website/screens/components/nav-tabs/NavTabsPageLayout.tsx
@@ -14,7 +14,7 @@ const NumberInputPageHeading = ({
     <DxcFlex direction="column" gap="3rem">
       <PageHeading>
         <DxcFlex direction="column" gap="2rem">
-          <ComponentHeading name="Nav Tabs" status="Experimental" />
+          <ComponentHeading name="Nav Tabs" status="Ready" />
           <DxcParagraph>
             Nav tabs allow the user to navigate easily.
           </DxcParagraph>

--- a/website/screens/components/paragraph/ParagraphPageLayout.tsx
+++ b/website/screens/components/paragraph/ParagraphPageLayout.tsx
@@ -1,10 +1,7 @@
 import PageHeading from "@/common/PageHeading";
-import {
-  DxcHeading,
-  DxcFlex,
-  DxcParagraph,
-} from "@dxc-technology/halstack-react";
+import { DxcFlex, DxcParagraph } from "@dxc-technology/halstack-react";
 import TabsPageHeading from "@/common/TabsPageLayout";
+import ComponentHeading from "@/common/ComponentHeading";
 
 const ParagraphPageHeading = ({ children }: { children: React.ReactNode }) => {
   const tabs = [
@@ -17,7 +14,7 @@ const ParagraphPageHeading = ({ children }: { children: React.ReactNode }) => {
     <DxcFlex direction="column" gap="3rem">
       <PageHeading>
         <DxcFlex direction="column" gap="2rem">
-          <DxcHeading level={1} text="Paragraph" weight="bold"></DxcHeading>
+          <ComponentHeading name="Paragraph" status="Ready" />
           <DxcParagraph>Paragraph is a block of text.</DxcParagraph>
           <TabsPageHeading tabs={tabs}></TabsPageHeading>
         </DxcFlex>

--- a/website/screens/components/quick-nav/QuickNavPageLayout.tsx
+++ b/website/screens/components/quick-nav/QuickNavPageLayout.tsx
@@ -10,7 +10,7 @@ const QuickNavPageHeading = ({ children }: { children: React.ReactNode }) => {
     <DxcFlex direction="column" gap="3rem">
       <PageHeading>
         <DxcFlex direction="column" gap="2rem">
-          <ComponentHeading name="Quick Nav" status="Experimental" />
+          <ComponentHeading name="Quick Nav" status="Ready" />
           <DxcParagraph>
             The quick nav component allows navigation inside a page. It renders
             the links according to the headings of the content in order to

--- a/website/screens/components/radio-group/RadioGroupPageLayout.tsx
+++ b/website/screens/components/radio-group/RadioGroupPageLayout.tsx
@@ -14,7 +14,7 @@ const RadioGroupPageHeading = ({ children }: { children: React.ReactNode }) => {
     <DxcFlex direction="column" gap="3rem">
       <PageHeading>
         <DxcFlex direction="column" gap="2rem">
-          <ComponentHeading name="Radio Group" status="Experimental" />
+          <ComponentHeading name="Radio Group" status="Ready" />
           <DxcParagraph>
             A radio group let the user make a mutually exclusive selection from
             a group of options.

--- a/website/screens/components/typography/TypographyPageLayout.tsx
+++ b/website/screens/components/typography/TypographyPageLayout.tsx
@@ -1,6 +1,7 @@
 import PageHeading from "@/common/PageHeading";
 import { DxcHeading, DxcFlex, DxcAlert } from "@dxc-technology/halstack-react";
 import TabsPageHeading from "@/common/TabsPageLayout";
+import ComponentHeading from "@/common/ComponentHeading";
 
 const TypographyPageHeading = ({ children }: { children: React.ReactNode }) => {
   const tabs = [
@@ -13,7 +14,7 @@ const TypographyPageHeading = ({ children }: { children: React.ReactNode }) => {
     <DxcFlex direction="column" gap="3rem">
       <PageHeading>
         <DxcFlex direction="column" gap="2rem">
-          <DxcHeading level={1} text="Typography" weight="bold"></DxcHeading>
+          <ComponentHeading name="Typography" status="Ready" />
           <DxcAlert type="warning" size="fillParent">
             Use this component only if all other Halstack Design System
             components for adding text DO NOT meet your requirements. This


### PR DESCRIPTION
### Changes
Changed status from `Experimental` to `Ready` in `Bleed`, `Bulleted List`, `Flex`, `Inset`, `Nav Tabs`, `Paragraph`, `Quick Nav`, `Radio Group` and `Typography` in website.