### PR TITLE
Increasing dialog content size

### DIFF
--- a/lib/src/dialog/Dialog.stories.tsx
+++ b/lib/src/dialog/Dialog.stories.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import DxcDialog from "./Dialog";
+import DxcTextInput from "../text-input/TextInput";
+import DxcButton from "../button/Button";
+import DxcFlex from "../flex/Flex";
 import Title from "../../.storybook/components/Title";
 import ExampleContainer from "../../.storybook/components/ExampleContainer";
 
@@ -25,6 +28,50 @@ export const DefaultDialog = () => (
           augue. Vivamus erat sapien, ultricies fringilla tellus id, condimentum blandit justo. Praesent quis nunc
           dignissim, pharetra neque molestie, molestie lectus.
         </p>{" "}
+      </DxcDialog>
+    </ExampleContainer>
+  </>
+);
+
+export const DialogWithInputs = () => (
+  <>
+    <ExampleContainer expanded={true}>
+      <Title title="Dialog with inputs" theme="light" level={4} />
+      <DxcDialog>
+        <DxcTextInput size="fillParent" label="Name"></DxcTextInput>
+        <DxcTextInput size="fillParent" label="Surname"></DxcTextInput>
+
+        <DxcFlex justifyContent="flex-end">
+          <DxcButton label="Save" margin="small" size="fitContent"></DxcButton>
+          <DxcButton
+            label="Cancel"
+            margin={{ top: "small", bottom: "small" }}
+            mode="secondary"
+            size="fitContent"
+          ></DxcButton>
+        </DxcFlex>
+      </DxcDialog>
+    </ExampleContainer>
+  </>
+);
+
+const RespDialog = () => (
+  <>
+    <ExampleContainer expanded={true}>
+      <Title title="Responsive dialog" theme="light" level={4} />
+      <DxcDialog>
+        <DxcTextInput size="fillParent" label="Name"></DxcTextInput>
+        <DxcTextInput size="fillParent" label="Surname"></DxcTextInput>
+
+        <DxcFlex justifyContent="flex-end">
+          <DxcButton label="Save" margin="small" size="fitContent"></DxcButton>
+          <DxcButton
+            label="Cancel"
+            margin={{ top: "small", bottom: "small" }}
+            mode="secondary"
+            size="fitContent"
+          ></DxcButton>
+        </DxcFlex>
       </DxcDialog>
     </ExampleContainer>
   </>
@@ -209,3 +256,11 @@ export const DialogWithXxlargePadding = () => (
     </DxcDialog>
   </ExampleContainer>
 );
+
+export const ResponsiveDialog = RespDialog.bind({});
+ResponsiveDialog.parameters = {
+  viewport: {
+    defaultViewport: "iphonex",
+  },
+  chromatic: { viewports: [375] },
+};

--- a/lib/src/dialog/Dialog.tsx
+++ b/lib/src/dialog/Dialog.tsx
@@ -108,6 +108,7 @@ const Dialog = styled.div<{ isCloseVisible?: boolean }>`
   box-shadow: ${(props) =>
     `${props.theme.boxShadowOffsetX} ${props.theme.boxShadowOffsetY} ${props.theme.boxShadowBlur} ${props.theme.boxShadowColor}`};
   border-radius: 4px;
+  position: relative;
 
   @media (min-width: ${responsiveSizes.medium}rem) {
     max-width: 80%;
@@ -124,7 +125,7 @@ const Dialog = styled.div<{ isCloseVisible?: boolean }>`
 const Children = styled.div<{ padding: Padding | Space }>`
   display: flex;
   flex-direction: column;
-
+  width: 100%;
   padding: ${(props) => (props.padding && typeof props.padding !== "object" ? spaces[props.padding] : spaces["small"])};
   padding-top: ${(props) =>
     props.padding && typeof props.padding === "object" && props.padding.top ? spaces[props.padding.top] : ""};
@@ -142,7 +143,7 @@ const CloseIconContainer = styled.button`
   margin: 0;
   background: none;
   border: none;
-  position: relative;
+  position: absolute;
   top: 20px;
   right: 20px;
   color: ${(props) => props.theme.closeIconColor};


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_
- [x] Build process is done without errors and all tests pass in `/lib` directory.
- [x] Self-reviewed the code prior to submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
A component that expects to have the whole width inside the dialog now works as expected.

**Description**
- Removed the space occupied by the close button making it absolute.
- Making the children's container have 100% width.
- Adding one visual test that covers this case and another one for the responsive case.

**Screenshots**
![image](https://user-images.githubusercontent.com/12238686/194860961-eaa36d62-06fd-4ccf-9b12-9403597ecca0.png)


**Closes #1328**