### PR TITLE
deprecating padding prop from accordion, box, card, dialog, footer & header

### DIFF
--- a/lib/src/accordion-group/types.ts
+++ b/lib/src/accordion-group/types.ts
@@ -31,8 +31,9 @@ export type AccordionPropsType = {
    */
   disabled?: boolean;
   /**
-   * Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+   * @deprecated Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
+   * The prop will be removed, use Inset instead.
    */
   padding?: Space | Padding;
   /**

--- a/lib/src/accordion-group/types.ts
+++ b/lib/src/accordion-group/types.ts
@@ -31,9 +31,9 @@ export type AccordionPropsType = {
    */
   disabled?: boolean;
   /**
-   * @deprecated Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+   * @deprecated This prop will be removed shortly, consider using the Inset component for this purpose.
+   *  Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
-   * The prop will be removed, use Inset instead.
    */
   padding?: Space | Padding;
   /**

--- a/lib/src/accordion-group/types.ts
+++ b/lib/src/accordion-group/types.ts
@@ -32,7 +32,7 @@ export type AccordionPropsType = {
   disabled?: boolean;
   /**
    * @deprecated This prop will be removed shortly, consider using the Inset component for this purpose.
-   *  Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+   * Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
    */
   padding?: Space | Padding;

--- a/lib/src/accordion/types.ts
+++ b/lib/src/accordion/types.ts
@@ -56,8 +56,9 @@ type Props = {
    */
   margin?: Space | Margin;
   /**
-   * Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+   * @deprecated Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
+   * The prop will be removed, use Inset instead.
    */
   padding?: Space | Padding;
   /**

--- a/lib/src/accordion/types.ts
+++ b/lib/src/accordion/types.ts
@@ -56,9 +56,9 @@ type Props = {
    */
   margin?: Space | Margin;
   /**
-   * @deprecated Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+   * @deprecated This prop will be removed shortly, consider using the Inset component for this purpose.
+   * Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
-   * The prop will be removed, use Inset instead.
    */
   padding?: Space | Padding;
   /**

--- a/lib/src/box/types.ts
+++ b/lib/src/box/types.ts
@@ -32,7 +32,7 @@ type Props = {
   margin?: Space | Margin;
   /**
    * @deprecated This prop will be removed shortly, consider using the Inset component for this purpose.
-   *  Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+   * Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
    * The prop will be removed, use Inset instead.
    */

--- a/lib/src/box/types.ts
+++ b/lib/src/box/types.ts
@@ -34,7 +34,6 @@ type Props = {
    * @deprecated This prop will be removed shortly, consider using the Inset component for this purpose.
    * Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
-   * The prop will be removed, use Inset instead.
    */
   padding?: Space | Padding;
   /**

--- a/lib/src/box/types.ts
+++ b/lib/src/box/types.ts
@@ -31,7 +31,8 @@ type Props = {
    */
   margin?: Space | Margin;
   /**
-   * @deprecated Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+   * @deprecated This prop will be removed shortly, consider using the Inset component for this purpose.
+   *  Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
    * The prop will be removed, use Inset instead.
    */

--- a/lib/src/box/types.ts
+++ b/lib/src/box/types.ts
@@ -31,8 +31,9 @@ type Props = {
    */
   margin?: Space | Margin;
   /**
-   * Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+   * @deprecated Size of the padding to be applied to the custom area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
+   * The prop will be removed, use Inset instead.
    */
   padding?: Space | Padding;
   /**

--- a/lib/src/card/types.ts
+++ b/lib/src/card/types.ts
@@ -47,9 +47,9 @@ type Props = {
    */
   margin?: Space | Size;
   /**
-   * @deprecated Size of the padding to be applied to the content area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+   * @deprecated This prop will be removed shortly, consider using the Inset component for this purpose.
+   * Size of the padding to be applied to the content area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
-   * The prop will be removed, use Inset instead.
    */
   contentPadding?: Space | Size;
   /**

--- a/lib/src/card/types.ts
+++ b/lib/src/card/types.ts
@@ -42,13 +42,14 @@ type Props = {
    */
   imageCover?: boolean;
   /**
-   * Size of the margin to be applied to the component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). 
+   * Size of the margin to be applied to the component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different margin sizes.
    */
   margin?: Space | Size;
   /**
-   * Size of the padding to be applied to the content area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'). 
+   * @deprecated Size of the padding to be applied to the content area ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
+   * The prop will be removed, use Inset instead.
    */
   contentPadding?: Space | Size;
   /**

--- a/lib/src/dialog/types.ts
+++ b/lib/src/dialog/types.ts
@@ -26,9 +26,9 @@ type Props = {
    */
   onBackgroundClick?: () => void;
   /**
-   * @deprecated Size of the padding to be applied to the component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+   * @deprecated This prop will be removed shortly, consider using the Inset component for this purpose.
+   * Size of the padding to be applied to the component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
-   * The prop will be removed, use Inset instead.
    */
   padding?: Padding | Space;
   /**

--- a/lib/src/dialog/types.ts
+++ b/lib/src/dialog/types.ts
@@ -26,8 +26,9 @@ type Props = {
    */
   onBackgroundClick?: () => void;
   /**
-   * Size of the padding to be applied to the component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+   * @deprecated Size of the padding to be applied to the component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in order to specify different padding sizes.
+   * The prop will be removed, use Inset instead.
    */
   padding?: Padding | Space;
   /**

--- a/lib/src/footer/types.ts
+++ b/lib/src/footer/types.ts
@@ -58,8 +58,9 @@ type FooterPropsType = {
    */
   margin?: Space | Size;
   /**
-   * Size of the padding to be applied to the custom area of the component.
+   * @deprecated Size of the padding to be applied to the custom area of the component.
    * You can pass an object with properties in order to specify different padding sizes.
+   * The prop will be removed, use Inset instead.
    */
   padding?: Space | Size;
 };

--- a/lib/src/footer/types.ts
+++ b/lib/src/footer/types.ts
@@ -58,9 +58,9 @@ type FooterPropsType = {
    */
   margin?: Space | Size;
   /**
-   * @deprecated Size of the padding to be applied to the custom area of the component.
+   * @deprecated This prop will be removed shortly, consider using the Inset component for this purpose.
+   * Size of the padding to be applied to the custom area of the component.
    * You can pass an object with properties in order to specify different padding sizes.
-   * The prop will be removed, use Inset instead.
    */
   padding?: Space | Size;
 };

--- a/lib/src/header/types.ts
+++ b/lib/src/header/types.ts
@@ -32,11 +32,11 @@ type Props = {
    */
   margin?: Space;
   /**
-   * @deprecated Size of the padding to be applied to the custom area of the component
+   * @deprecated This prop will be removed shortly, consider using the Inset component for this purpose.
+   * Size of the padding to be applied to the custom area of the component
    * ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in
    * order to specify different padding sizes.
-   * The prop will be removed, use Inset instead.
    */
   padding?: Space | Padding;
   /**

--- a/lib/src/header/types.ts
+++ b/lib/src/header/types.ts
@@ -32,10 +32,11 @@ type Props = {
    */
   margin?: Space;
   /**
-   * Size of the padding to be applied to the custom area of the component
+   * @deprecated Size of the padding to be applied to the custom area of the component
    * ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
    * You can pass an object with 'top', 'bottom', 'left' and 'right' properties in
    * order to specify different padding sizes.
+   * The prop will be removed, use Inset instead.
    */
   padding?: Space | Padding;
   /**

--- a/website/screens/components/accordion/code/AccordionCodePage.tsx
+++ b/website/screens/components/accordion/code/AccordionCodePage.tsx
@@ -24,12 +24,12 @@ const sections = [
     title: "Props",
     content: (
       <DxcAlert type="warning" size="fillParent">
-        The padding prop is deprecated, consider using layout components like
-        the{" "}
+        The <Code>padding</Code> prop has been deprecated. Consider using layout
+        components like the{" "}
         <Link href="/components/inset/" passHref>
           <DxcLink>inset</DxcLink>
-        </Link>
-        .
+        </Link>{" "}
+        for the same purpose.
       </DxcAlert>
     ),
     subSections: [

--- a/website/screens/components/accordion/code/AccordionCodePage.tsx
+++ b/website/screens/components/accordion/code/AccordionCodePage.tsx
@@ -2,6 +2,8 @@ import {
   DxcFlex,
   DxcTable,
   DxcParagraph,
+  DxcAlert,
+  DxcLink,
 } from "@dxc-technology/halstack-react";
 import QuickNavContainer from "@/common/QuickNavContainer";
 import QuickNavContainerLayout from "@/common/QuickNavContainerLayout";
@@ -14,10 +16,22 @@ import icons from "./examples/icons";
 import controlledAccordionGroup from "./examples/controlledAccordionGroup";
 import uncontrolledAccordionGroup from "./examples/uncontrolledAccordionGroup";
 import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
+import StatusTag from "@/common/StatusTag";
+import Link from "next/link";
 
 const sections = [
   {
     title: "Props",
+    content: (
+      <DxcAlert type="warning" size="fillParent">
+        The padding prop is deprecated, consider using layout components like
+        the{" "}
+        <Link href="/components/inset/" passHref>
+          <DxcLink>inset</DxcLink>
+        </Link>
+        .
+      </DxcAlert>
+    ),
     subSections: [
       {
         title: "Accordion",
@@ -107,11 +121,18 @@ const sections = [
                 <td>padding: string | object</td>
                 <td></td>
                 <td>
-                  Size of the padding to be applied to the custom area
-                  ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' |
-                  'xlarge' | 'xxlarge'). You can pass an object with 'top',
-                  'bottom', 'left' and 'right' properties in order to specify
-                  different padding sizes.
+                  <DxcFlex
+                    gap="0.25rem"
+                    direction="column"
+                    alignItems="baseline"
+                  >
+                    <StatusTag status="Deprecated">Deprecated</StatusTag>
+                    Size of the padding to be applied to the custom area
+                    ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' |
+                    'xlarge' | 'xxlarge'). You can pass an object with 'top',
+                    'bottom', 'left' and 'right' properties in order to specify
+                    different padding sizes.
+                  </DxcFlex>
                 </td>
               </tr>
               <tr>
@@ -246,11 +267,20 @@ const sections = [
                         <td>padding: string | object</td>
                         <td></td>
                         <td>
-                          Size of the padding to be applied to the custom area
-                          ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' |
-                          'xlarge' | 'xxlarge'). You can pass an object with
-                          'top', 'bottom', 'left' and 'right' properties in
-                          order to specify different padding sizes.
+                          <DxcFlex
+                            gap="0.25rem"
+                            direction="column"
+                            alignItems="baseline"
+                          >
+                            <StatusTag status="Deprecated">
+                              Deprecated
+                            </StatusTag>
+                            Size of the padding to be applied to the custom area
+                            ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large'
+                            | 'xlarge' | 'xxlarge'). You can pass an object with
+                            'top', 'bottom', 'left' and 'right' properties in
+                            order to specify different padding sizes.
+                          </DxcFlex>
                         </td>
                       </tr>
                     </tbody>

--- a/website/screens/components/accordion/code/AccordionCodePage.tsx
+++ b/website/screens/components/accordion/code/AccordionCodePage.tsx
@@ -27,7 +27,7 @@ const sections = [
         The <Code>padding</Code> prop has been deprecated. Consider using layout
         components like the{" "}
         <Link href="/components/inset/" passHref>
-          <DxcLink>inset</DxcLink>
+          <DxcLink>Inset</DxcLink>
         </Link>{" "}
         for the same purpose.
       </DxcAlert>

--- a/website/screens/components/box/code/BoxCodePage.tsx
+++ b/website/screens/components/box/code/BoxCodePage.tsx
@@ -1,4 +1,9 @@
-import { DxcFlex, DxcTable } from "@dxc-technology/halstack-react";
+import {
+  DxcAlert,
+  DxcFlex,
+  DxcLink,
+  DxcTable,
+} from "@dxc-technology/halstack-react";
 import QuickNavContainerLayout from "@/common/QuickNavContainerLayout";
 import QuickNavContainer from "@/common/QuickNavContainer";
 import Code from "@/common/Code";
@@ -6,71 +11,87 @@ import DocFooter from "@/common/DocFooter";
 import Example from "@/common/example/Example";
 import basicUsage from "./examples/basicUsage";
 import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
+import StatusTag from "@/common/StatusTag";
+import Link from "next/link";
 
 const sections = [
   {
     title: "Props",
     content: (
-      <DxcTable>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Default</th>
-            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>shadowDepth: 0 | 1 | 2</td>
-            <td>
-              <Code>2</Code>
-            </td>
-            <td>The size of the shadow to be displayed around the box.</td>
-          </tr>
-          <tr>
-            <td>display: string</td>
-            <td>
-              <Code>'inline-flex'</Code>
-            </td>
-            <td>Changes the display CSS property of the box div.</td>
-          </tr>
-          <tr>
-            <td>children: node</td>
-            <td></td>
-            <td>Custom content that will be placed in the box component.</td>
-          </tr>
-          <tr>
-            <td>margin: string | object</td>
-            <td></td>
-            <td>
-              Size of the margin to be applied to the component ('xxsmall' |
-              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
-              You can pass an object with 'top', 'bottom', 'left' and 'right'
-              properties in order to specify different margin sizes.
-            </td>
-          </tr>
-          <tr>
-            <td>padding: string | object</td>
-            <td></td>
-            <td>
-              Size of the padding to be applied to the component ('xxsmall' |
-              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
-              You can pass an object with 'top', 'bottom', 'left' and 'right'
-              properties in order to specify different padding sizes.
-            </td>
-          </tr>
-          <tr>
-            <td>size: string</td>
-            <td>
-              <Code>'fitContent'</Code>
-            </td>
-            <td>
-              Size of the component ('small' | 'medium' | 'large' |
-              'fillParent'| 'fitContent').
-            </td>
-          </tr>
-        </tbody>
-      </DxcTable>
+      <>
+        <DxcAlert type="warning" size="fillParent">
+          The padding prop is deprecated, consider using layout components like
+          the{" "}
+          <Link href="/components/inset/" passHref>
+            <DxcLink>inset</DxcLink>
+          </Link>
+          .
+        </DxcAlert>
+        <DxcTable>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Default</th>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>shadowDepth: 0 | 1 | 2</td>
+              <td>
+                <Code>2</Code>
+              </td>
+              <td>The size of the shadow to be displayed around the box.</td>
+            </tr>
+            <tr>
+              <td>display: string</td>
+              <td>
+                <Code>'inline-flex'</Code>
+              </td>
+              <td>Changes the display CSS property of the box div.</td>
+            </tr>
+            <tr>
+              <td>children: node</td>
+              <td></td>
+              <td>Custom content that will be placed in the box component.</td>
+            </tr>
+            <tr>
+              <td>margin: string | object</td>
+              <td></td>
+              <td>
+                Size of the margin to be applied to the component ('xxsmall' |
+                'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+                You can pass an object with 'top', 'bottom', 'left' and 'right'
+                properties in order to specify different margin sizes.
+              </td>
+            </tr>
+            <tr>
+              <td>padding: string | object</td>
+              <td></td>
+              <td>
+                <DxcFlex gap="0.25rem" direction="column" alignItems="baseline">
+                  <StatusTag status="Deprecated">Deprecated</StatusTag>
+                  Size of the padding to be applied to the component ('xxsmall'
+                  | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' |
+                  'xxlarge'). You can pass an object with 'top', 'bottom',
+                  'left' and 'right' properties in order to specify different
+                  padding sizes.
+                </DxcFlex>
+              </td>
+            </tr>
+            <tr>
+              <td>size: string</td>
+              <td>
+                <Code>'fitContent'</Code>
+              </td>
+              <td>
+                Size of the component ('small' | 'medium' | 'large' |
+                'fillParent'| 'fitContent').
+              </td>
+            </tr>
+          </tbody>
+        </DxcTable>
+      </>
     ),
   },
   {

--- a/website/screens/components/box/code/BoxCodePage.tsx
+++ b/website/screens/components/box/code/BoxCodePage.tsx
@@ -20,12 +20,12 @@ const sections = [
     content: (
       <>
         <DxcAlert type="warning" size="fillParent">
-          The padding prop is deprecated, consider using layout components like
-          the{" "}
+          The <Code>padding</Code> prop has been deprecated. Consider using
+          layout components like the{" "}
           <Link href="/components/inset/" passHref>
             <DxcLink>inset</DxcLink>
-          </Link>
-          .
+          </Link>{" "}
+          for the same purpose.
         </DxcAlert>
         <DxcTable>
           <thead>

--- a/website/screens/components/box/code/BoxCodePage.tsx
+++ b/website/screens/components/box/code/BoxCodePage.tsx
@@ -23,7 +23,7 @@ const sections = [
           The <Code>padding</Code> prop has been deprecated. Consider using
           layout components like the{" "}
           <Link href="/components/inset/" passHref>
-            <DxcLink>inset</DxcLink>
+            <DxcLink>Inset</DxcLink>
           </Link>{" "}
           for the same purpose.
         </DxcAlert>

--- a/website/screens/components/card/code/CardCodePage.tsx
+++ b/website/screens/components/card/code/CardCodePage.tsx
@@ -23,7 +23,7 @@ const sections = [
           The <Code>contentPadding</Code> prop has been deprecated. Consider
           using layout components like the{" "}
           <Link href="/components/inset/" passHref>
-            <DxcLink>inset</DxcLink>
+            <DxcLink>Inset</DxcLink>
           </Link>{" "}
           for the same purpose.
         </DxcAlert>

--- a/website/screens/components/card/code/CardCodePage.tsx
+++ b/website/screens/components/card/code/CardCodePage.tsx
@@ -20,12 +20,12 @@ const sections = [
     content: (
       <>
         <DxcAlert type="warning" size="fillParent">
-          The contentPadding prop is deprecated, consider using layout
-          components like the{" "}
+          The <Code>contentPadding</Code> prop has been deprecated. Consider
+          using layout components like the{" "}
           <Link href="/components/inset/" passHref>
             <DxcLink>inset</DxcLink>
-          </Link>
-          .
+          </Link>{" "}
+          for the same purpose.
         </DxcAlert>
         <DxcTable>
           <thead>

--- a/website/screens/components/card/code/CardCodePage.tsx
+++ b/website/screens/components/card/code/CardCodePage.tsx
@@ -1,4 +1,9 @@
-import { DxcFlex, DxcTable } from "@dxc-technology/halstack-react";
+import {
+  DxcAlert,
+  DxcFlex,
+  DxcLink,
+  DxcTable,
+} from "@dxc-technology/halstack-react";
 import QuickNavContainer from "@/common/QuickNavContainer";
 import QuickNavContainerLayout from "@/common/QuickNavContainerLayout";
 import DocFooter from "@/common/DocFooter";
@@ -6,12 +11,22 @@ import Example from "@/common/example/Example";
 import Code from "@/common/Code";
 import basicUsage from "./examples/basicUsage";
 import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
+import StatusTag from "@/common/StatusTag";
+import Link from "next/link";
 
 const sections = [
   {
     title: "Props",
     content: (
       <>
+        <DxcAlert type="warning" size="fillParent">
+          The contentPadding prop is deprecated, consider using layout
+          components like the{" "}
+          <Link href="/components/inset/" passHref>
+            <DxcLink>inset</DxcLink>
+          </Link>
+          .
+        </DxcAlert>
         <DxcTable>
           <thead>
             <tr>
@@ -97,11 +112,14 @@ const sections = [
               <td>contentPadding: string | object</td>
               <td></td>
               <td>
-                Size of the padding to be applied to the content area (`xxsmall`
-                | `xsmall` | `small` | `medium` | `large` | `xlarge` |
-                `xxlarge`). You can pass an object with `top`, `bottom`, `left`
-                and `right` properties in order to specify different padding
-                sizes.
+                <DxcFlex gap="0.25rem" direction="column" alignItems="baseline">
+                  <StatusTag status="Deprecated">Deprecated</StatusTag>
+                  Size of the padding to be applied to the content area
+                  (`xxsmall` | `xsmall` | `small` | `medium` | `large` |
+                  `xlarge` | `xxlarge`). You can pass an object with `top`,
+                  `bottom`, `left` and `right` properties in order to specify
+                  different padding sizes.
+                </DxcFlex>
               </td>
             </tr>
             <tr>

--- a/website/screens/components/dialog/code/DialogCodePage.tsx
+++ b/website/screens/components/dialog/code/DialogCodePage.tsx
@@ -26,7 +26,7 @@ const sections = [
           The <Code>padding</Code> prop has been deprecated. Consider using
           layout components like the{" "}
           <Link href="/components/inset/" passHref>
-            <DxcLink>inset</DxcLink>
+            <DxcLink>Inset</DxcLink>
           </Link>{" "}
           for the same purpose.
         </DxcAlert>

--- a/website/screens/components/dialog/code/DialogCodePage.tsx
+++ b/website/screens/components/dialog/code/DialogCodePage.tsx
@@ -23,12 +23,12 @@ const sections = [
     content: (
       <>
         <DxcAlert type="warning" size="fillParent">
-          The padding prop is deprecated, consider using layout components like
-          the{" "}
+          The <Code>padding</Code> prop has been deprecated. Consider using
+          layout components like the{" "}
           <Link href="/components/inset/" passHref>
             <DxcLink>inset</DxcLink>
-          </Link>
-          .
+          </Link>{" "}
+          for the same purpose.
         </DxcAlert>
         <DxcTable>
           <thead>

--- a/website/screens/components/dialog/code/DialogCodePage.tsx
+++ b/website/screens/components/dialog/code/DialogCodePage.tsx
@@ -2,6 +2,8 @@ import {
   DxcParagraph,
   DxcFlex,
   DxcTable,
+  DxcAlert,
+  DxcLink,
 } from "@dxc-technology/halstack-react";
 import Code from "@/common/Code";
 import DocFooter from "@/common/DocFooter";
@@ -12,83 +14,99 @@ import basicUsage from "./examples/basicUsage";
 import withContent from "./examples/withContent";
 import backgroundClick from "./examples/backgroundClick";
 import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
+import StatusTag from "@/common/StatusTag";
+import Link from "next/link";
 
 const sections = [
   {
     title: "Props",
     content: (
-      <DxcTable>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Default</th>
-            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>isCloseVisible: boolean</td>
-            <td>
-              <Code>true</Code>
-            </td>
-            <td>If true, the close 'x' button will be visible.</td>
-          </tr>
-          <tr>
-            <td>onCloseClick: function</td>
-            <td></td>
-            <td>
-              This function will be called when the user clicks the close 'x'
-              button. The responsibility of hiding the dialog lies with the
-              user.
-            </td>
-          </tr>
-          <tr>
-            <td>onBackgroundClick: function</td>
-            <td></td>
-            <td>
-              This function will be called when the user clicks background. The
-              responsibility of hiding the dialog lies with the user.
-            </td>
-          </tr>
-          <tr>
-            <td>overlay: boolean</td>
-            <td>
-              <Code>true</Code>
-            </td>
-            <td>
-              If true, the dialog will be displayed over a darker background
-              that covers the content behind.
-            </td>
-          </tr>
-          <tr>
-            <td>padding: string | object</td>
-            <td>
-              <Code>'small'</Code>
-            </td>
-            <td>
-              Size of the padding to be applied to the component ('xxsmall' |
-              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
-              You can pass an object with 'top', 'bottom', 'left' and 'right'
-              properties in order to specify different padding sizes.
-            </td>
-          </tr>
-          <tr>
-            <td>tabIndex: number</td>
-            <td>
-              <Code>0</Code>
-            </td>
-            <td>Value of the tabindex given to the close 'x' button.</td>
-          </tr>
-          <tr>
-            <td>children: node</td>
-            <td></td>
-            <td>
-              The area inside the dialog. This area can be used to render custom
-              content.
-            </td>
-          </tr>
-        </tbody>
-      </DxcTable>
+      <>
+        <DxcAlert type="warning" size="fillParent">
+          The padding prop is deprecated, consider using layout components like
+          the{" "}
+          <Link href="/components/inset/" passHref>
+            <DxcLink>inset</DxcLink>
+          </Link>
+          .
+        </DxcAlert>
+        <DxcTable>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Default</th>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>isCloseVisible: boolean</td>
+              <td>
+                <Code>true</Code>
+              </td>
+              <td>If true, the close 'x' button will be visible.</td>
+            </tr>
+            <tr>
+              <td>onCloseClick: function</td>
+              <td></td>
+              <td>
+                This function will be called when the user clicks the close 'x'
+                button. The responsibility of hiding the dialog lies with the
+                user.
+              </td>
+            </tr>
+            <tr>
+              <td>onBackgroundClick: function</td>
+              <td></td>
+              <td>
+                This function will be called when the user clicks background.
+                The responsibility of hiding the dialog lies with the user.
+              </td>
+            </tr>
+            <tr>
+              <td>overlay: boolean</td>
+              <td>
+                <Code>true</Code>
+              </td>
+              <td>
+                If true, the dialog will be displayed over a darker background
+                that covers the content behind.
+              </td>
+            </tr>
+            <tr>
+              <td>padding: string | object</td>
+              <td>
+                <Code>'small'</Code>
+              </td>
+              <td>
+                <DxcFlex gap="0.25rem" direction="column" alignItems="baseline">
+                  <StatusTag status="Deprecated">Deprecated</StatusTag>
+                  Size of the padding to be applied to the component ('xxsmall'
+                  | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' |
+                  'xxlarge'). You can pass an object with 'top', 'bottom',
+                  'left' and 'right' properties in order to specify different
+                  padding sizes.
+                </DxcFlex>
+              </td>
+            </tr>
+            <tr>
+              <td>tabIndex: number</td>
+              <td>
+                <Code>0</Code>
+              </td>
+              <td>Value of the tabindex given to the close 'x' button.</td>
+            </tr>
+            <tr>
+              <td>children: node</td>
+              <td></td>
+              <td>
+                The area inside the dialog. This area can be used to render
+                custom content.
+              </td>
+            </tr>
+          </tbody>
+        </DxcTable>
+      </>
     ),
   },
   {

--- a/website/screens/components/footer/code/FooterCodePage.tsx
+++ b/website/screens/components/footer/code/FooterCodePage.tsx
@@ -1,105 +1,125 @@
-import { DxcFlex, DxcTable } from "@dxc-technology/halstack-react";
+import {
+  DxcAlert,
+  DxcFlex,
+  DxcLink,
+  DxcTable,
+} from "@dxc-technology/halstack-react";
 import QuickNavContainer from "@/common/QuickNavContainer";
 import QuickNavContainerLayout from "@/common/QuickNavContainerLayout";
 import DocFooter from "@/common/DocFooter";
 import Code from "@/common/Code";
 import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
+import StatusTag from "@/common/StatusTag";
+import Link from "next/link";
 
 const sections = [
   {
     title: "Props",
     content: (
-      <DxcTable>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Default</th>
-            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>socialLinks: object[]</td>
-            <td>
-              <Code>[]</Code>
-            </td>
-            <td>
-              An array of objects representing the links that will be rendered
-              as icons at the top-right side of the footer. Each object has the
-              following properties:
-              <ul>
-                <li>
-                  <b>logo</b>: Element or path used as the icon for the link.
-                </li>
-                <li>
-                  <b>href</b>: URL of the page the link goes to.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>bottomLinks: object[]</td>
-            <td>
-              <Code>[]</Code>
-            </td>
-            <td>
-              An array of objects representing the links that will be rendered
-              at the bottom part of the footer. Each object has the following
-              properties:
-              <ul>
-                <li>
-                  <b>text</b>: Text for the link.
-                </li>
-                <li>
-                  <b>href</b>: URL of the page the link goes to.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>copyright: string</td>
-            <td></td>
-            <td>The text that will be displayed as copyright disclaimer.</td>
-          </tr>
-          <tr>
-            <td>children: node</td>
-            <td></td>
-            <td>
-              The center section of the footer. Can be used to render custom
-              content in this area.
-            </td>
-          </tr>
-          <tr>
-            <td>margin: string</td>
-            <td></td>
-            <td>
-              Size of the top margin to be applied to the footer ('xxsmall' |
-              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
-            </td>
-          </tr>
-          <tr>
-            <td>padding: string | object</td>
-            <td></td>
-            <td>
-              Size of the padding to be applied to the custom area of the
-              component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' |
-              'xlarge' | 'xxlarge'). You can pass an object with 'top',
-              'bottom', 'left' and 'right' properties in order to specify
-              different padding sizes.
-            </td>
-          </tr>
-          <tr>
-            <td>tabIndex: number</td>
-            <td>
-              <Code>0</Code>
-            </td>
-            <td>
-              Value of the tabindex for all interactuable elements, except those
-              inside the custom area.
-            </td>
-          </tr>
-        </tbody>
-      </DxcTable>
+      <>
+        <DxcAlert type="warning" size="fillParent">
+          The padding prop is deprecated, consider using layout components like
+          the{" "}
+          <Link href="/components/inset/" passHref>
+            <DxcLink>inset</DxcLink>
+          </Link>
+          .
+        </DxcAlert>
+        <DxcTable>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Default</th>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>socialLinks: object[]</td>
+              <td>
+                <Code>[]</Code>
+              </td>
+              <td>
+                An array of objects representing the links that will be rendered
+                as icons at the top-right side of the footer. Each object has
+                the following properties:
+                <ul>
+                  <li>
+                    <b>logo</b>: Element or path used as the icon for the link.
+                  </li>
+                  <li>
+                    <b>href</b>: URL of the page the link goes to.
+                  </li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td>bottomLinks: object[]</td>
+              <td>
+                <Code>[]</Code>
+              </td>
+              <td>
+                An array of objects representing the links that will be rendered
+                at the bottom part of the footer. Each object has the following
+                properties:
+                <ul>
+                  <li>
+                    <b>text</b>: Text for the link.
+                  </li>
+                  <li>
+                    <b>href</b>: URL of the page the link goes to.
+                  </li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td>copyright: string</td>
+              <td></td>
+              <td>The text that will be displayed as copyright disclaimer.</td>
+            </tr>
+            <tr>
+              <td>children: node</td>
+              <td></td>
+              <td>
+                The center section of the footer. Can be used to render custom
+                content in this area.
+              </td>
+            </tr>
+            <tr>
+              <td>margin: string</td>
+              <td></td>
+              <td>
+                Size of the top margin to be applied to the footer ('xxsmall' |
+                'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
+              </td>
+            </tr>
+            <tr>
+              <td>padding: string | object</td>
+              <td></td>
+              <td>
+                <DxcFlex gap="0.25rem" direction="column" alignItems="baseline">
+                  <StatusTag status="Deprecated">Deprecated</StatusTag>
+                  Size of the padding to be applied to the custom area of the
+                  component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large'
+                  | 'xlarge' | 'xxlarge'). You can pass an object with 'top',
+                  'bottom', 'left' and 'right' properties in order to specify
+                  different padding sizes.
+                </DxcFlex>
+              </td>
+            </tr>
+            <tr>
+              <td>tabIndex: number</td>
+              <td>
+                <Code>0</Code>
+              </td>
+              <td>
+                Value of the tabindex for all interactuable elements, except
+                those inside the custom area.
+              </td>
+            </tr>
+          </tbody>
+        </DxcTable>
+      </>
     ),
   },
   {

--- a/website/screens/components/footer/code/FooterCodePage.tsx
+++ b/website/screens/components/footer/code/FooterCodePage.tsx
@@ -18,12 +18,12 @@ const sections = [
     content: (
       <>
         <DxcAlert type="warning" size="fillParent">
-          The padding prop is deprecated, consider using layout components like
-          the{" "}
+          The <Code>padding</Code> prop has been deprecated. Consider using
+          layout components like the{" "}
           <Link href="/components/inset/" passHref>
             <DxcLink>inset</DxcLink>
-          </Link>
-          .
+          </Link>{" "}
+          for the same purpose.
         </DxcAlert>
         <DxcTable>
           <thead>

--- a/website/screens/components/footer/code/FooterCodePage.tsx
+++ b/website/screens/components/footer/code/FooterCodePage.tsx
@@ -21,7 +21,7 @@ const sections = [
           The <Code>padding</Code> prop has been deprecated. Consider using
           layout components like the{" "}
           <Link href="/components/inset/" passHref>
-            <DxcLink>inset</DxcLink>
+            <DxcLink>Inset</DxcLink>
           </Link>{" "}
           for the same purpose.
         </DxcAlert>

--- a/website/screens/components/header/code/HeaderCodePage.tsx
+++ b/website/screens/components/header/code/HeaderCodePage.tsx
@@ -3,6 +3,7 @@ import {
   DxcTable,
   DxcParagraph,
   DxcLink,
+  DxcAlert,
 } from "@dxc-technology/halstack-react";
 import Code from "@/common/Code";
 import DocFooter from "@/common/DocFooter";
@@ -11,86 +12,103 @@ import QuickNavContainerLayout from "@/common/QuickNavContainerLayout";
 import Link from "next/link";
 import React from "react";
 import HeaderDescriptionCell from "@/common/HeaderDescriptionCell";
+import StatusTag from "@/common/StatusTag";
 
 const sections = [
   {
     title: "Props",
     content: (
-      <DxcTable>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Default</th>
-            <HeaderDescriptionCell>Description</HeaderDescriptionCell>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>underlined: boolean</td>
-            <td>
-              <Code>false</Code>
-            </td>
-            <td>
-              Wether a contrast line should appear at the bottom of the header.
-            </td>
-          </tr>
-          <tr>
-            <td>content: node</td>
-            <td></td>
-            <td>
-              Content showed in the header. Take into account that the component
-              applies styles for the first child in the content, so we recommend
-              the use of React.Fragment to be applied correctly. Otherwise, the
-              styles can be modified.
-            </td>
-          </tr>
-          <tr>
-            <td>responsiveContent: function</td>
-            <td></td>
-            <td>
-              Content showed in responsive version. It receives the close menu
-              handler that can be used to add that functionality when a element
-              is clicked.
-            </td>
-          </tr>
-          <tr>
-            <td>onClick: function</td>
-            <td></td>
-            <td>
-              This function will be called when the user clicks the header logo.
-            </td>
-          </tr>
-          <tr>
-            <td>margin: string</td>
-            <td></td>
-            <td>
-              Size of the bottom margin to be applied to the header ('xxsmall' |
-              'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge').
-            </td>
-          </tr>
-          <tr>
-            <td>padding: string | object</td>
-            <td></td>
-            <td>
-              Size of the padding to be applied to the custom area of the
-              component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' |
-              'xlarge' | 'xxlarge'). You can pass an object with 'top',
-              'bottom', 'left' and 'right' properties in order to specify
-              different padding sizes.
-            </td>
-          </tr>
-          <tr>
-            <td>tabIndex: number</td>
-            <td>
-              <Code>0</Code>
-            </td>
-            <td>
-              Value of the tabindex for all interactuable elements, except those
-              inside the custom area.
-            </td>
-          </tr>
-        </tbody>
-      </DxcTable>
+      <>
+        <DxcAlert type="warning" size="fillParent">
+          The padding prop is deprecated, consider using layout components like
+          the{" "}
+          <Link href="/components/inset/" passHref>
+            <DxcLink>inset</DxcLink>
+          </Link>
+          .
+        </DxcAlert>
+        <DxcTable>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Default</th>
+              <HeaderDescriptionCell>Description</HeaderDescriptionCell>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>underlined: boolean</td>
+              <td>
+                <Code>false</Code>
+              </td>
+              <td>
+                Wether a contrast line should appear at the bottom of the
+                header.
+              </td>
+            </tr>
+            <tr>
+              <td>content: node</td>
+              <td></td>
+              <td>
+                Content showed in the header. Take into account that the
+                component applies styles for the first child in the content, so
+                we recommend the use of React.Fragment to be applied correctly.
+                Otherwise, the styles can be modified.
+              </td>
+            </tr>
+            <tr>
+              <td>responsiveContent: function</td>
+              <td></td>
+              <td>
+                Content showed in responsive version. It receives the close menu
+                handler that can be used to add that functionality when a
+                element is clicked.
+              </td>
+            </tr>
+            <tr>
+              <td>onClick: function</td>
+              <td></td>
+              <td>
+                This function will be called when the user clicks the header
+                logo.
+              </td>
+            </tr>
+            <tr>
+              <td>margin: string</td>
+              <td></td>
+              <td>
+                Size of the bottom margin to be applied to the header ('xxsmall'
+                | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' |
+                'xxlarge').
+              </td>
+            </tr>
+            <tr>
+              <td>padding: string | object</td>
+              <td></td>
+              <td>
+                <DxcFlex gap="0.25rem" direction="column" alignItems="baseline">
+                  <StatusTag status="Deprecated">Deprecated</StatusTag>
+                  Size of the padding to be applied to the custom area of the
+                  component ('xxsmall' | 'xsmall' | 'small' | 'medium' | 'large'
+                  | 'xlarge' | 'xxlarge'). You can pass an object with 'top',
+                  'bottom', 'left' and 'right' properties in order to specify
+                  different padding sizes.
+                </DxcFlex>
+              </td>
+            </tr>
+            <tr>
+              <td>tabIndex: number</td>
+              <td>
+                <Code>0</Code>
+              </td>
+              <td>
+                Value of the tabindex for all interactuable elements, except
+                those inside the custom area.
+              </td>
+            </tr>
+          </tbody>
+        </DxcTable>
+      </>
     ),
   },
   {

--- a/website/screens/components/header/code/HeaderCodePage.tsx
+++ b/website/screens/components/header/code/HeaderCodePage.tsx
@@ -20,12 +20,12 @@ const sections = [
     content: (
       <>
         <DxcAlert type="warning" size="fillParent">
-          The padding prop is deprecated, consider using layout components like
-          the{" "}
+          The <Code>padding</Code> prop has been deprecated. Consider using
+          layout components like the{" "}
           <Link href="/components/inset/" passHref>
             <DxcLink>inset</DxcLink>
-          </Link>
-          .
+          </Link>{" "}
+          for the same purpose.
         </DxcAlert>
         <DxcTable>
           <thead>

--- a/website/screens/components/header/code/HeaderCodePage.tsx
+++ b/website/screens/components/header/code/HeaderCodePage.tsx
@@ -23,7 +23,7 @@ const sections = [
           The <Code>padding</Code> prop has been deprecated. Consider using
           layout components like the{" "}
           <Link href="/components/inset/" passHref>
-            <DxcLink>inset</DxcLink>
+            <DxcLink>Inset</DxcLink>
           </Link>{" "}
           for the same purpose.
         </DxcAlert>


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_
- [x] Build process is done without errors and all tests pass in `/lib` directory.
- [x] Self-reviewed the code prior to submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
Update the documentation of affected components (accordion, box, card, dialog, footer & header) as having the prop padding deprecated. The positioning has been consulted with a designer previously.

**Screenshots**
![image](https://user-images.githubusercontent.com/12238686/196122481-6701a70d-8fd3-4247-8b92-76637bcd3a96.png)
Added alert to props sections of affected components.

![image](https://user-images.githubusercontent.com/12238686/196123041-85de56e8-d18b-4267-8aac-8c678ee1d4fc.png)
Also, the deprecated tag has been added to the prop in the table.

**Closes #1297**