### PR TITLE
Using transient props in Flex component

### DIFF
--- a/lib/src/flex/Flex.tsx
+++ b/lib/src/flex/Flex.tsx
@@ -1,35 +1,52 @@
 import React from "react";
 import styled from "styled-components";
-import FlexPropsType from "./types";
+import FlexPropsType, { StyledProps } from "./types";
 
-const DxcFlex = ({ children, ...props }: FlexPropsType): JSX.Element => <Flex {...props}>{children}</Flex>;
+const DxcFlex = ({
+  direction = "row",
+  wrap = "nowrap",
+  gap = "0",
+  order = 0,
+  grow = 0,
+  shrink = 1,
+  basis = "auto",
+  children,
+  ...props
+}: FlexPropsType): JSX.Element => (
+  <Flex
+    $direction={direction}
+    $wrap={wrap}
+    $order={order}
+    $grow={grow}
+    $shrink={shrink}
+    $basis={basis}
+    $gap={gap}
+    {...props}
+  >
+    {children}
+  </Flex>
+);
 
-const Flex = styled.div<FlexPropsType>`
+const Flex = styled.div<StyledProps>`
   display: flex;
   ${({
-    direction = "row",
-    wrap = "nowrap",
     justifyContent = "flex-start",
     alignItems = "stretch",
     alignContent = "normal",
     alignSelf = "auto",
-    gap = "0",
-    order = 0,
-    grow = 0,
-    shrink = 1,
-    basis = "auto",
+    ...props
   }) => `
-    flex-direction: ${direction}; 
-    flex-wrap: ${wrap}; 
+    flex-direction: ${props.$direction}; 
+    flex-wrap: ${props.$wrap}; 
     justify-content: ${justifyContent}; 
     align-items: ${alignItems};
     align-content: ${alignContent};
     align-self: ${alignSelf};
-    gap: ${typeof gap === "object" ? `${gap.rowGap} ${gap.columnGap}` : gap};
-    order: ${order};
-    flex-grow: ${grow};
-    flex-shrink: ${shrink};
-    flex-basis: ${basis};
+    gap: ${typeof props.$gap === "object" ? `${props.$gap.rowGap} ${props.$gap.columnGap}` : props.$gap};
+    order: ${props.$order};
+    flex-grow: ${props.$grow};
+    flex-shrink: ${props.$shrink};
+    flex-basis: ${props.$basis};
   `}
 `;
 

--- a/lib/src/flex/types.ts
+++ b/lib/src/flex/types.ts
@@ -1,8 +1,6 @@
 type Gap = { rowGap: string; columnGap: string };
 
-type Props = {
-  direction?: "row" | "row-reverse" | "column" | "column-reverse";
-  wrap?: "nowrap" | "wrap" | "wrap-reverse";
+type CommonProps = {
   justifyContent?:
     | "flex-start"
     | "flex-end"
@@ -36,6 +34,11 @@ type Props = {
     | "space-evenly"
     | "stretch";
   alignSelf?: "auto" | "flex-start" | "flex-end" | "center" | "baseline" | "stretch";
+};
+
+type Props = CommonProps & {
+  direction?: "row" | "row-reverse" | "column" | "column-reverse";
+  wrap?: "nowrap" | "wrap" | "wrap-reverse";
   gap?: string | Gap;
   order?: number;
   grow?: number;
@@ -43,6 +46,16 @@ type Props = {
   basis?: string;
   as?: keyof HTMLElementTagNameMap;
   children: React.ReactNode;
+};
+
+export type StyledProps = CommonProps & {
+  $direction?: "row" | "row-reverse" | "column" | "column-reverse";
+  $wrap?: "nowrap" | "wrap" | "wrap-reverse";
+  $gap?: string | Gap;
+  $order?: number;
+  $grow?: number;
+  $shrink?: number;
+  $basis?: string;
 };
 
 export default Props;


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_
- [ ] Build process is done without errors and all tests pass in the `/lib` directory.
- [ ] Self-reviewed the code before submitting.
- [ ] Meets accessibility standards.
- [ ] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Description**
To avoid passing some specific props that could be potentially HTML attributes, styled-components offer what they called **transient props**. These are regular props marked with the symbol `$` so the library understands that they shouldn't be passed to the underlying component.

**Screenshots**
![image](https://user-images.githubusercontent.com/44321109/197202265-bf11503c-717b-441a-bef2-3f1f3075854a.png)


**Additional context**
[What transient props are](https://styled-components.com/docs/api#transient-props)
https://medium.com/@probablyup/introducing-transient-props-f35fd5203e0c
https://dev.to/sarahscode/props-are-not-forever-preventing-props-from-being-passed-to-the-dom-with-styled-components-v5-1-l47

**Closes #1343 **