### PR TITLE
Table fixed padding in last row item

### DIFF
--- a/lib/src/table/Table.tsx
+++ b/lib/src/table/Table.tsx
@@ -93,6 +93,9 @@ const DxcTableContent = styled.table`
   & th:last-child {
     border-top-right-radius: ${(props) => props.theme.headerBorderRadius};
   }
+  & td:last-child {
+    padding-right: 40px;
+  }
 `;
 
 export default DxcTable;


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_
- [x] Build process is done without errors and all tests pass in `/lib` directory.
- [x] Self-reviewed the code prior to submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
Padding from cells wasn't matching with the design guidelines.

**Description**
Added padding 40px to right side of the last cell of the rows.

**Screenshots**
![image](https://user-images.githubusercontent.com/34685461/199018646-5ec1eead-0955-48e0-ab68-e4c9d5a559bc.png)

**Closes #1340**