### PR TITLE
Table fixed height rows

### DIFF
--- a/lib/src/resultsetTable/ResultsetTable.tsx
+++ b/lib/src/resultsetTable/ResultsetTable.tsx
@@ -168,9 +168,6 @@ const TableRowGroup = styled.tbody`
     left: calc(50% - 68.5px);
     bottom: calc(50% - 68.5px - 30px);
   }
-  & tr {
-    height: ${(props) => props.theme.rowHeight || "70px"};
-  }
 `;
 const SortIcon = styled.div`
   top: 409px;

--- a/lib/src/table/Table.tsx
+++ b/lib/src/table/Table.tsx
@@ -60,6 +60,7 @@ const DxcTableContent = styled.table`
   & tr {
     border-bottom: ${(props) =>
       `${props.theme.rowSeparatorThickness} ${props.theme.rowSeparatorStyle} ${props.theme.rowSeparatorColor}`};
+    height: 60px;
   }
   & td {
     background-color: ${(props) => props.theme.dataBackgroundColor};


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_
- [x] Build process is done without errors and all tests pass in `/lib` directory.
- [x] Self-reviewed the code prior to submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
Height rows in table and resultset table were not as in the design guidelines.

**Description**
Resultset table was using a token which didn't exist so I removed it. Added `height: 60px` in the table for the rows. This fixed will be applied in both components.

**Screenshots**
![image](https://user-images.githubusercontent.com/34685461/199025347-a69e59ec-0a2f-4e0b-8cf6-91e4054bb0dd.png)

**Closes #1339**