### PR TITLE
Fix dropdown menu resize when label changes

### DIFF
--- a/lib/src/dropdown/Dropdown.tsx
+++ b/lib/src/dropdown/Dropdown.tsx
@@ -157,7 +157,7 @@ const DxcDropdown = ({
     return () => {
       window.removeEventListener("resize", handleMenuResize);
     };
-  }, []);
+  }, [label]);
 
   return (
     <ThemeProvider theme={colorsTheme.dropdown}>


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_
- [x] Build process is done without errors and all tests pass in `/lib` directory.
- [x] Self-reviewed the code prior to submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Description**
`label` prop is included in the `useEffect` that executes the resize of the dropdown menu.

**Screenshots**
Screenshots from this code:
```
const [label, setLabel] = useState("1");

  useEffect(() => {
    new Promise((resolve, reject) => {
      setTimeout(() => {
        resolve("foo");
      }, 1000);
    }).then(() => {
      setLabel("vicrodriguezgu");
    });
  }, []);

  return (
    <>
      <ExampleContainer>
        <Title title="Default" theme="light" level={4} />
        <DxcDropdown label={label} options={options} onSelectOption={(value) => {}} />
      </ExampleContainer>
    </>
  );
```

Before:
![image](https://user-images.githubusercontent.com/35959222/201915645-8855fa73-8581-413b-a68b-84658587ae24.png)

After:
![image](https://user-images.githubusercontent.com/35959222/201915518-f200bf88-b9d7-4385-b914-c8d1734dc8c0.png)


**Closes #1374**