### PR TITLE
Fixed autosuggest input with special characters

### DIFF
--- a/lib/src/text-input/Suggestion.tsx
+++ b/lib/src/text-input/Suggestion.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components";
 import { SuggestionProps } from "./types";
 
@@ -24,10 +24,10 @@ const Suggestion = ({
   visuallyFocused,
   highlighted,
 }: SuggestionProps): JSX.Element => {
-  const specialChar = transformSpecialChars(value);
-  const regEx = new RegExp(specialChar, "i");
-  const matchedWords = suggestion.match(regEx);
-  const noMatchedWords = suggestion.replace(regEx, "");
+  const matchedSuggestion = useMemo(() => {
+    const regEx = new RegExp(transformSpecialChars(value), "i");
+    return { matchedWords: suggestion.match(regEx), noMatchedWords: suggestion.replace(regEx, "") };
+  }, [value, suggestion]);
 
   return (
     <SuggestionContainer
@@ -42,8 +42,8 @@ const Suggestion = ({
       <StyledSuggestion last={isLast} visuallyFocused={visuallyFocused}>
         {highlighted ? (
           <>
-            <strong>{matchedWords}</strong>
-            {noMatchedWords}
+            <strong>{matchedSuggestion.matchedWords}</strong>
+            {matchedSuggestion.noMatchedWords}
           </>
         ) : (
           suggestion

--- a/lib/src/text-input/Suggestion.tsx
+++ b/lib/src/text-input/Suggestion.tsx
@@ -2,6 +2,15 @@ import React from "react";
 import styled from "styled-components";
 import { SuggestionProps } from "./types";
 
+const transformSpecialChars = (str: string) => {
+  const specialChars = "[\\`!@#$%^&*()_+-=[]{};':\"|,.<>/?~]/";
+  let value = str;
+  specialChars.split("").forEach((specialChar) => {
+    if (str.includes(specialChar)) value = value.replace(specialChar, "\\" + specialChar);
+  });
+  return value;
+};
+
 const Suggestion = ({
   id,
   value,
@@ -11,7 +20,9 @@ const Suggestion = ({
   visuallyFocused,
   highlighted,
 }: SuggestionProps): JSX.Element => {
-  const regEx = new RegExp(value, "i");
+  const format = /[\\`!@#$%^&*()_+\-=\[\]{};':"|,.<>\/?~]/;
+  const special = transformSpecialChars(value);
+  const regEx = new RegExp(format.test(value) ? special : value, "i");
   const matchedWords = suggestion.match(regEx);
   const noMatchedWords = suggestion.replace(regEx, "");
 

--- a/lib/src/text-input/Suggestion.tsx
+++ b/lib/src/text-input/Suggestion.tsx
@@ -3,11 +3,12 @@ import styled from "styled-components";
 import { SuggestionProps } from "./types";
 
 const transformSpecialChars = (str: string) => {
-  const specialChars = "[\\`!@#$%^&*()_+-=[]{};':\"|,.<>/?~]/";
-  const specialCharsRegex = /[\\`!@#$%^&*()_+\-=\[\]{};':"|,.<>\/?~]/;
+  const specialCharsRegex = /[\\*()\[\]{}+?/]/;
   let value = str;
   if (specialCharsRegex.test(value)) {
-    specialChars.split("").forEach((specialChar) => {
+    const regexAsString = specialCharsRegex.toString().split("");
+    const uniqueSpecialChars = regexAsString.filter((item, index) => regexAsString.indexOf(item) === index);
+    uniqueSpecialChars.forEach((specialChar) => {
       if (str.includes(specialChar)) value = value.replace(specialChar, "\\" + specialChar);
     });
   }

--- a/lib/src/text-input/Suggestion.tsx
+++ b/lib/src/text-input/Suggestion.tsx
@@ -4,10 +4,13 @@ import { SuggestionProps } from "./types";
 
 const transformSpecialChars = (str: string) => {
   const specialChars = "[\\`!@#$%^&*()_+-=[]{};':\"|,.<>/?~]/";
+  const specialCharsRegex = /[\\`!@#$%^&*()_+\-=\[\]{};':"|,.<>\/?~]/;
   let value = str;
-  specialChars.split("").forEach((specialChar) => {
-    if (str.includes(specialChar)) value = value.replace(specialChar, "\\" + specialChar);
-  });
+  if (specialCharsRegex.test(value)) {
+    specialChars.split("").forEach((specialChar) => {
+      if (str.includes(specialChar)) value = value.replace(specialChar, "\\" + specialChar);
+    });
+  }
   return value;
 };
 
@@ -20,9 +23,8 @@ const Suggestion = ({
   visuallyFocused,
   highlighted,
 }: SuggestionProps): JSX.Element => {
-  const format = /[\\`!@#$%^&*()_+\-=\[\]{};':"|,.<>\/?~]/;
-  const special = transformSpecialChars(value);
-  const regEx = new RegExp(format.test(value) ? special : value, "i");
+  const specialChar = transformSpecialChars(value);
+  let regEx = new RegExp(specialChar, "i");
   const matchedWords = suggestion.match(regEx);
   const noMatchedWords = suggestion.replace(regEx, "");
 

--- a/lib/src/text-input/Suggestion.tsx
+++ b/lib/src/text-input/Suggestion.tsx
@@ -25,7 +25,7 @@ const Suggestion = ({
   highlighted,
 }: SuggestionProps): JSX.Element => {
   const specialChar = transformSpecialChars(value);
-  let regEx = new RegExp(specialChar, "i");
+  const regEx = new RegExp(specialChar, "i");
   const matchedWords = suggestion.match(regEx);
   const noMatchedWords = suggestion.replace(regEx, "");
 

--- a/lib/src/text-input/TextInput.stories.tsx
+++ b/lib/src/text-input/TextInput.stories.tsx
@@ -61,6 +61,7 @@ const countries = [
   "Dominica",
   "Denmark",
   "Djibouti",
+  "*",
 ];
 
 export const Chromatic = () => (
@@ -308,7 +309,11 @@ const AutosuggestListbox = () => {
       <ExampleContainer>
         <Title title="Autosuggest listbox" theme="light" level={2} />
         <ExampleContainer>
-          <Title title="List dialog uses a Radix Popover to appear over elements with a certain z-index" theme="light" level={3} />
+          <Title
+            title="List dialog uses a Radix Popover to appear over elements with a certain z-index"
+            theme="light"
+            level={3}
+          />
           <div
             style={{
               display: "flex",

--- a/lib/src/text-input/TextInput.test.js
+++ b/lib/src/text-input/TextInput.test.js
@@ -44,7 +44,7 @@ const countries = [
   "Djibouti",
 ];
 
-const special_characters = ["/", "\\", "*", "(", ")", "[", "]", "+", "?", "*{[]}|"];
+const specialCharacters = ["/", "\\", "*", "(", ")", "[", "]", "+", "?", "*{[]}|"];
 
 describe("TextInput component tests", () => {
   test("Renders with correct error aria attributes", () => {
@@ -649,7 +649,7 @@ describe("TextInput component synchronous autosuggest tests", () => {
   test("Autosuggest escapes special characters", () => {
     const onChange = jest.fn();
     const { getAllByText, getByText, getByRole } = render(
-      <DxcTextInput label="Autocomplete Countries" suggestions={special_characters} onChange={onChange} />
+      <DxcTextInput label="Autocomplete Countries" suggestions={specialCharacters} onChange={onChange} />
     );
     const input = getByRole("combobox");
     fireEvent.focus(input);
@@ -657,41 +657,30 @@ describe("TextInput component synchronous autosuggest tests", () => {
     fireEvent.change(input, { target: { value: "/" } });
     expect(list).toBeTruthy();
     expect(getAllByText("/").length).toBe(1);
-    expect(getByText("/")).toBeTruthy();
     fireEvent.change(input, { target: { value: "\\" } });
     expect(list).toBeTruthy();
     expect(getAllByText("\\").length).toBe(1);
-    expect(getByText("\\")).toBeTruthy();
     fireEvent.change(input, { target: { value: "*" } });
     expect(list).toBeTruthy();
     expect(getAllByText("*").length).toBe(2);
-    expect(getAllByText("*")[0]).toBeTruthy();
-    expect(getAllByText("*")[1]).toBeTruthy();
-    expect(getByText("{[]}|")).toBeTruthy();
     fireEvent.change(input, { target: { value: "(" } });
     expect(list).toBeTruthy();
     expect(getAllByText("(").length).toBe(1);
-    expect(getByText("(")).toBeTruthy();
     fireEvent.change(input, { target: { value: ")" } });
     expect(list).toBeTruthy();
     expect(getAllByText(")").length).toBe(1);
-    expect(getByText(")")).toBeTruthy();
     fireEvent.change(input, { target: { value: "[" } });
     expect(list).toBeTruthy();
     expect(getAllByText("[").length).toBe(1);
-    expect(getByText("[")).toBeTruthy();
     fireEvent.change(input, { target: { value: "]" } });
     expect(list).toBeTruthy();
     expect(getAllByText("]").length).toBe(1);
-    expect(getByText("]")).toBeTruthy();
     fireEvent.change(input, { target: { value: "+" } });
     expect(list).toBeTruthy();
     expect(getAllByText("+").length).toBe(1);
-    expect(getByText("+")).toBeTruthy();
     fireEvent.change(input, { target: { value: "?" } });
     expect(list).toBeTruthy();
     expect(getAllByText("?").length).toBe(1);
-    expect(getByText("?")).toBeTruthy();
   });
 });
 

--- a/lib/src/text-input/TextInput.test.js
+++ b/lib/src/text-input/TextInput.test.js
@@ -44,7 +44,7 @@ const countries = [
   "Djibouti",
 ];
 
-const special_characters = ["/", "\\", "*", "*{[]}|"];
+const special_characters = ["/", "\\", "*", "(", ")", "[", "]", "+", "?", "*{[]}|"];
 
 describe("TextInput component tests", () => {
   test("Renders with correct error aria attributes", () => {
@@ -668,6 +668,30 @@ describe("TextInput component synchronous autosuggest tests", () => {
     expect(getAllByText("*")[0]).toBeTruthy();
     expect(getAllByText("*")[1]).toBeTruthy();
     expect(getByText("{[]}|")).toBeTruthy();
+    fireEvent.change(input, { target: { value: "(" } });
+    expect(list).toBeTruthy();
+    expect(getAllByText("(").length).toBe(1);
+    expect(getByText("(")).toBeTruthy();
+    fireEvent.change(input, { target: { value: ")" } });
+    expect(list).toBeTruthy();
+    expect(getAllByText(")").length).toBe(1);
+    expect(getByText(")")).toBeTruthy();
+    fireEvent.change(input, { target: { value: "[" } });
+    expect(list).toBeTruthy();
+    expect(getAllByText("[").length).toBe(1);
+    expect(getByText("[")).toBeTruthy();
+    fireEvent.change(input, { target: { value: "]" } });
+    expect(list).toBeTruthy();
+    expect(getAllByText("]").length).toBe(1);
+    expect(getByText("]")).toBeTruthy();
+    fireEvent.change(input, { target: { value: "+" } });
+    expect(list).toBeTruthy();
+    expect(getAllByText("+").length).toBe(1);
+    expect(getByText("+")).toBeTruthy();
+    fireEvent.change(input, { target: { value: "?" } });
+    expect(list).toBeTruthy();
+    expect(getAllByText("?").length).toBe(1);
+    expect(getByText("?")).toBeTruthy();
   });
 });
 

--- a/lib/src/text-input/TextInput.test.js
+++ b/lib/src/text-input/TextInput.test.js
@@ -44,6 +44,8 @@ const countries = [
   "Djibouti",
 ];
 
+const special_characters = ["/", "\\", "*", "*{[]}|"];
+
 describe("TextInput component tests", () => {
   test("Renders with correct error aria attributes", () => {
     const { getByText, getByRole } = render(
@@ -642,6 +644,30 @@ describe("TextInput component synchronous autosuggest tests", () => {
     fireEvent.keyDown(input, { key: "Esc", code: "Esp", keyCode: 27, charCode: 27 });
     expect(input.value).toBe("");
     expect(queryByRole("listbox")).toBeFalsy();
+  });
+
+  test("Autosuggest escapes special characters", () => {
+    const onChange = jest.fn();
+    const { getAllByText, getByText, getByRole } = render(
+      <DxcTextInput label="Autocomplete Countries" suggestions={special_characters} onChange={onChange} />
+    );
+    const input = getByRole("combobox");
+    fireEvent.focus(input);
+    const list = getByRole("listbox");
+    fireEvent.change(input, { target: { value: "/" } });
+    expect(list).toBeTruthy();
+    expect(getAllByText("/").length).toBe(1);
+    expect(getByText("/")).toBeTruthy();
+    fireEvent.change(input, { target: { value: "\\" } });
+    expect(list).toBeTruthy();
+    expect(getAllByText("\\").length).toBe(1);
+    expect(getByText("\\")).toBeTruthy();
+    fireEvent.change(input, { target: { value: "*" } });
+    expect(list).toBeTruthy();
+    expect(getAllByText("*").length).toBe(2);
+    expect(getAllByText("*")[0]).toBeTruthy();
+    expect(getAllByText("*")[1]).toBeTruthy();
+    expect(getByText("{[]}|")).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_
- [x] Build process is done without errors and all tests pass in `/lib` directory.
- [x] Self-reviewed the code prior to submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Description**
Special characters were transformed to regular expression so it was giving an error if they were invalid. 
Added `\` to escape the special characters. For example, if we write `*` in the input, internally the component will transform the value received to `\*` so it will be valid.
Added new test.

About the implementation, I have created a regular expression with the special characters that are giving error. Then I have converted it to string and created an array with each character. It is needed to remove the duplicate characters from the array because the function `.toString()` is literally converting the regular expression in a string without removing the characters `/`, `[` and `]` that are used to create de regular expresion (example, `const a = /[a-z]/`).

**Screenshots**
Created a new function to transform the value:
![image](https://user-images.githubusercontent.com/34685461/213415475-ecba2260-9a05-4838-ada3-ac5fee15c97f.png)


**Closes #1416**