### PR TITLE
Added nav tabs previews to theme generator

### DIFF
--- a/lib/src/nav-tabs/Tab.tsx
+++ b/lib/src/nav-tabs/Tab.tsx
@@ -35,6 +35,7 @@ const DxcTab = forwardRef(
         <Tab
           href={!disabled && href ? href : undefined}
           disabled={disabled}
+          active={active}
           iconPosition={iconPosition}
           hasIcon={hasIcons}
           ref={(anchorRef) => {
@@ -112,6 +113,7 @@ const TabContainer = styled.div<TabContainerProps>`
 type TabStyleProps = {
   disabled: boolean;
   hasIcon: boolean;
+  active?: boolean;
   iconPosition: "top" | "left";
 };
 const Tab = styled.a<TabStyleProps>`
@@ -122,7 +124,8 @@ const Tab = styled.a<TabStyleProps>`
 
   text-decoration-color: transparent;
   cursor: ${(props) => (props.disabled ? "not-allowed" : "pointer")};
-  background: ${(props) => props.theme.selectedBackgroundColor};
+  background: ${(props) =>
+    props.active ? props.theme.selectedBackgroundColor : props.theme.unselectedBackgroundColor};
 
   height: ${(props) => (props.hasIcon && props.iconPosition === "top" ? "66px" : "32px")};
   min-width: 164px;

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@dxc-technology/halstack-react": "0.0.0-a5b9b2c",
+    "@dxc-technology/halstack-react": "0.0.0-dcee34a",
     "@radix-ui/react-popover": "0.1.6",
     "@types/styled-components": "^5.1.18",
     "axios": "^0.27.2",

--- a/website/screens/theme-generator/components/ComponentsPreviewMap.ts
+++ b/website/screens/theme-generator/components/ComponentsPreviewMap.ts
@@ -31,6 +31,7 @@ import FooterPreview from "./previews/Footer";
 import HeaderPreview from "./previews/Header";
 import BulletedListPreview from "./previews/BulletedList";
 import ParagraphPreview from "./previews/Paragraph";
+import NavTabsPreview from "./previews/NavTabs";
 
 const SampleComponents = [
   {
@@ -96,6 +97,10 @@ const SampleComponents = [
   {
     name: "link",
     preview: LinkPreview,
+  },
+  {
+    name: "navTabs",
+    preview: NavTabsPreview,
   },
   {
     name: "textarea",

--- a/website/screens/theme-generator/components/previews/NavTabs.tsx
+++ b/website/screens/theme-generator/components/previews/NavTabs.tsx
@@ -12,7 +12,7 @@ const iconSVG = (
 
 const NavTabs = () => (
   <PreviewContainer>
-    <Mode text="Default">
+    <Mode text="Default ">
       <DxcNavTabs>
         <DxcNavTabs.Tab href="#" active>
           Tab 1

--- a/website/screens/theme-generator/components/previews/NavTabs.tsx
+++ b/website/screens/theme-generator/components/previews/NavTabs.tsx
@@ -12,7 +12,7 @@ const iconSVG = (
 
 const NavTabs = () => (
   <PreviewContainer>
-    <Mode text="Default ">
+    <Mode text="Default">
       <DxcNavTabs>
         <DxcNavTabs.Tab href="#" active>
           Tab 1

--- a/website/screens/theme-generator/components/previews/NavTabs.tsx
+++ b/website/screens/theme-generator/components/previews/NavTabs.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { DxcNavTabs } from "@dxc-technology/halstack-react";
+import Mode from "../Mode";
+import PreviewContainer from "./PreviewContainer";
+
+const iconSVG = (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <path d="M0 0h24v24H0z" fill="none" />
+    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+  </svg>
+);
+
+const NavTabs = () => (
+  <PreviewContainer>
+    <Mode text="Default">
+      <DxcNavTabs>
+        <DxcNavTabs.Tab href="#" active>
+          Tab 1
+        </DxcNavTabs.Tab>
+        <DxcNavTabs.Tab href="#" disabled>
+          Tab 2
+        </DxcNavTabs.Tab>
+        <DxcNavTabs.Tab href="#">Tab 3</DxcNavTabs.Tab>
+        <DxcNavTabs.Tab href="#">Tab 4</DxcNavTabs.Tab>
+      </DxcNavTabs>
+    </Mode>
+    <Mode text="With icon and notification">
+      <DxcNavTabs iconPosition="left">
+        <DxcNavTabs.Tab href="#" active icon={iconSVG} notificationNumber>
+          Tab 1
+        </DxcNavTabs.Tab>
+        <DxcNavTabs.Tab href="#" disabled icon={iconSVG} notificationNumber={5}>
+          Tab 2
+        </DxcNavTabs.Tab>
+        <DxcNavTabs.Tab href="#" icon={iconSVG} notificationNumber={120}>
+          Tab 3
+        </DxcNavTabs.Tab>
+        <DxcNavTabs.Tab href="#" icon={iconSVG}>
+          Tab 4
+        </DxcNavTabs.Tab>
+      </DxcNavTabs>
+    </Mode>
+  </PreviewContainer>
+);
+
+export default NavTabs;


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_
- [x] Build process is done without errors and all tests pass in `/lib` directory.
- [x] Self-reviewed the code prior to submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
Nav tabs previews are left in theme generator, so its opinionated theme cannot be changed.

**Description**
Nav tabs previews added to theme generator.

**Screenshots**
![image](https://user-images.githubusercontent.com/10975289/222130303-85d6d893-02e2-46a0-8c2e-7af2a9f87c96.png)

**Closes #1502**