### PR TITLE
Fix select a file after remove it in file input

### DIFF
--- a/lib/src/file-input/FileInput.tsx
+++ b/lib/src/file-input/FileInput.tsx
@@ -105,6 +105,7 @@ const DxcFileInput = React.forwardRef<RefType, FileInputPropsType>(
       const selectedFiles = e.target.files;
       const filesArray = Object.keys(selectedFiles).map((key) => selectedFiles[key]);
       addFile(filesArray);
+      e.target.value = null;
     };
 
     const onDelete = useCallback(


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_
- [x] Build process is done without errors and all tests pass in `/lib` directory.
- [x] Self-reviewed the code prior to submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
Fix to be able to select same file after remove it.

**Description**
Select a file, remove it and select the same file again. This is a limitation of the input file. Input file's value must be cleaned in order to be able to select it again.

Please refer to this [issue](https://github.com/ngokevin/react-file-reader-input/issues/11).

**Closes #1489**