### PR TITLE
Fixing Localization page error

### DIFF
--- a/lib/src/HalstackContext.tsx
+++ b/lib/src/HalstackContext.tsx
@@ -350,8 +350,7 @@ const parseTheme = (theme: DeepPartial<OpinionatedTheme>): AdvancedTheme => {
 };
 
 const parseLabels = (labels: DeepPartial<TranslatedLabels>): TranslatedLabels => {
-  const parsedLabels = JSON.parse(JSON.stringify(defaultTranslatedComponentLabels));
-
+  const parsedLabels = defaultTranslatedComponentLabels;
   Object.keys(labels).map((component) => {
     if (parsedLabels[component]) {
       Object.keys(parsedLabels[component]).map((label) => {

--- a/lib/src/accordion/Accordion.stories.tsx
+++ b/lib/src/accordion/Accordion.stories.tsx
@@ -131,7 +131,7 @@ export const Chromatic = () => (
       <DxcAccordion
         label="Accordion"
         assistiveText="Assistive text"
-        icon="https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons/images/icon-and-image-large-icon-settings_2x.png"
+        icon="https://www.freepnglogos.com/uploads/facebook-logo-design-1.png"
       >
         <div>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo

--- a/lib/src/button/Button.stories.tsx
+++ b/lib/src/button/Button.stories.tsx
@@ -98,7 +98,7 @@ export const Chromatic = () => (
     </ExampleContainer>
     <ExampleContainer>
       <Title title="Big icon (image)" theme="light" level={4} />
-      <DxcButton icon="https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons/images/icon-and-image-large-icon-settings_2x.png" />
+      <DxcButton icon="https://www.freepnglogos.com/uploads/facebook-logo-design-1.png" />
     </ExampleContainer>
     <ExampleContainer>
       <Title title="Small icon" theme="light" level={4} />

--- a/website/screens/principles/localization/examples/translations.ts
+++ b/website/screens/principles/localization/examples/translations.ts
@@ -24,8 +24,8 @@ const code = `() => {
       clearFieldActionTitle: "Limpiar",
     },
     paginator: {
-      itemsPerPageText: " Número de elementos",
-      pageOfText: (a, b) => \`Pagina: \${a} de \${b}\`,
+      itemsPerPageText: "Número de elementos: ",
+      pageOfText: (a, b) => \`Página: \${a} de \${b}\`,
     },
   };
 


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_
- [x] Build process is done without errors and all tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Description**
The problem was the `JSON.parse(JSON.stringify(defaultTranslatedComponentLabels));` line at the method `parseLabels`. HalstackProvider `labels` object is not serializable (the object has functions inside), so the JSON methods won't work with this object, causing the error.

Also, the URL to an icon in both Accordion and Button stories was not founded anymore. Updated.

**Closes #1584**