### PR TITLE
Paginator fix when itemsPerPage is 0

### DIFF
--- a/lib/src/paginator/Paginator.stories.tsx
+++ b/lib/src/paginator/Paginator.stories.tsx
@@ -67,6 +67,10 @@ export const Chromatic = () => (
         showGoToPage
       />
     </ExampleContainer>
+    <ExampleContainer>
+      <Title title="itemsPerPage is 0 and showGoToPage is true" theme="light" level={4} />
+      <DxcPaginator itemsPerPage={0} itemsPerPageOptions={[5, 10, 15]} totalItems={27} showGoToPage />
+    </ExampleContainer>
     <Title title="Opinionated theme" theme="light" level={2} />
     <ExampleContainer>
       <HalstackProvider theme={opinionatedTheme}>

--- a/lib/src/paginator/Paginator.stories.tsx
+++ b/lib/src/paginator/Paginator.stories.tsx
@@ -67,10 +67,6 @@ export const Chromatic = () => (
         showGoToPage
       />
     </ExampleContainer>
-    <ExampleContainer>
-      <Title title="itemsPerPage is 0 and showGoToPage is true" theme="light" level={4} />
-      <DxcPaginator itemsPerPage={0} itemsPerPageOptions={[5, 10, 15]} totalItems={27} showGoToPage />
-    </ExampleContainer>
     <Title title="Opinionated theme" theme="light" level={2} />
     <ExampleContainer>
       <HalstackProvider theme={opinionatedTheme}>

--- a/lib/src/paginator/Paginator.test.js
+++ b/lib/src/paginator/Paginator.test.js
@@ -22,19 +22,19 @@ global.DOMRect = {
 
 describe("Paginator component tests", () => {
   test("Paginator renders with default values", () => {
-    const { getByText } = render(<DxcPaginator></DxcPaginator>);
+    const { getByText } = render(<DxcPaginator />);
     expect(getByText("1 to 1 of 1")).toBeTruthy();
     expect(getByText("Page: 1 of 1")).toBeTruthy();
   });
 
   test("Paginator renders with currentPage", () => {
-    const { getByText } = render(<DxcPaginator currentPage={2}></DxcPaginator>);
+    const { getByText } = render(<DxcPaginator currentPage={2} />);
     expect(getByText("Page: 2 of 1")).toBeTruthy();
   });
 
   test("Paginator renders with itemsPerPageOptions", () => {
     const { getByText } = render(
-      <DxcPaginator currentPage={1} itemsPerPage={10} itemsPerPageOptions={[10, 15]} totalItems={20}></DxcPaginator>
+      <DxcPaginator currentPage={1} itemsPerPage={10} itemsPerPageOptions={[10, 15]} totalItems={20} />
     );
     expect(getByText("Items per page:")).toBeTruthy();
     expect(getByText("1 to 10 of 20")).toBeTruthy();
@@ -42,21 +42,19 @@ describe("Paginator component tests", () => {
   });
 
   test("Paginator renders with totalItems", () => {
-    const { getByText } = render(<DxcPaginator totalItems={20}></DxcPaginator>);
+    const { getByText } = render(<DxcPaginator totalItems={20} />);
     expect(getByText("1 to 5 of 20")).toBeTruthy();
     expect(getByText("Page: 1 of 4")).toBeTruthy();
   });
 
   test("Paginator renders with correct text in second page", () => {
-    const { getByText } = render(<DxcPaginator currentPage={2} itemsPerPage={10} totalItems={20}></DxcPaginator>);
+    const { getByText } = render(<DxcPaginator currentPage={2} itemsPerPage={10} totalItems={20} />);
     expect(getByText("11 to 20 of 20")).toBeTruthy();
     expect(getByText("Page: 2 of 2")).toBeTruthy();
   });
 
   test("Paginator renders goToPage select", () => {
-    const { getByText } = render(
-      <DxcPaginator currentPage={2} showGoToPage itemsPerPage={10} totalItems={20}></DxcPaginator>
-    );
+    const { getByText } = render(<DxcPaginator currentPage={2} showGoToPage itemsPerPage={10} totalItems={20} />);
     expect(getByText("Go to page:")).toBeTruthy();
   });
 
@@ -81,7 +79,7 @@ describe("Paginator component tests", () => {
   test("Call correct goToPageFunction", () => {
     const onClick = jest.fn();
     const { getAllByRole } = render(
-      <DxcPaginator onPageChange={onClick} currentPage={1} itemsPerPage={10} totalItems={20}></DxcPaginator>
+      <DxcPaginator onPageChange={onClick} currentPage={1} itemsPerPage={10} totalItems={20} />
     );
     const nextButton = getAllByRole("button")[2];
     userEvent.click(nextButton);
@@ -115,7 +113,7 @@ describe("Paginator component tests", () => {
   test("Next button is disable in last page", () => {
     const onClick = jest.fn();
     const { getAllByRole } = render(
-      <DxcPaginator onPageChange={onClick} currentPage={2} itemsPerPage={10} totalItems={20}></DxcPaginator>
+      <DxcPaginator onPageChange={onClick} currentPage={2} itemsPerPage={10} totalItems={20} />
     );
     const nextButton = getAllByRole("button")[2];
     expect(nextButton.hasAttribute("disabled")).toBeTruthy();
@@ -126,7 +124,7 @@ describe("Paginator component tests", () => {
   test("Last button is disable in last page", () => {
     const onClick = jest.fn();
     const { getAllByRole } = render(
-      <DxcPaginator onPageChange={onClick} currentPage={2} itemsPerPage={10} totalItems={20}></DxcPaginator>
+      <DxcPaginator onPageChange={onClick} currentPage={2} itemsPerPage={10} totalItems={20} />
     );
     const lastButton = getAllByRole("button")[3];
     expect(lastButton.hasAttribute("disabled")).toBeTruthy();
@@ -137,7 +135,7 @@ describe("Paginator component tests", () => {
   test("First button is disable in first page", () => {
     const onClick = jest.fn();
     const { getAllByRole } = render(
-      <DxcPaginator onPageChange={onClick} currentPage={1} itemsPerPage={10} totalItems={20}></DxcPaginator>
+      <DxcPaginator onPageChange={onClick} currentPage={1} itemsPerPage={10} totalItems={20} />
     );
     const lastButton = getAllByRole("button")[0];
     expect(lastButton.hasAttribute("disabled")).toBeTruthy();
@@ -148,7 +146,7 @@ describe("Paginator component tests", () => {
   test("Previous button is disable in first page", () => {
     const onClick = jest.fn();
     const { getAllByRole } = render(
-      <DxcPaginator onPageChange={onClick} currentPage={1} itemsPerPage={10} totalItems={20}></DxcPaginator>
+      <DxcPaginator onPageChange={onClick} currentPage={1} itemsPerPage={10} totalItems={20} />
     );
     const lastButton = getAllByRole("button")[1];
     expect(lastButton.hasAttribute("disabled")).toBeTruthy();
@@ -159,7 +157,7 @@ describe("Paginator component tests", () => {
   test("Last and next buttons are disable in last page", () => {
     const onClick = jest.fn();
     const { getAllByRole } = render(
-      <DxcPaginator onPageChange={onClick} currentPage={2} itemsPerPage={10} totalItems={20}></DxcPaginator>
+      <DxcPaginator onPageChange={onClick} currentPage={2} itemsPerPage={10} totalItems={20} />
     );
     const firstButton = getAllByRole("button")[0];
     const prevButton = getAllByRole("button")[1];
@@ -174,7 +172,7 @@ describe("Paginator component tests", () => {
   test("First and previous buttons are disable in first page", () => {
     const onClick = jest.fn();
     const { getAllByRole } = render(
-      <DxcPaginator onPageChange={onClick} currentPage={1} itemsPerPage={10} totalItems={20}></DxcPaginator>
+      <DxcPaginator onPageChange={onClick} currentPage={1} itemsPerPage={10} totalItems={20} />
     );
     const firstButton = getAllByRole("button")[0];
     const prevButton = getAllByRole("button")[1];
@@ -184,5 +182,13 @@ describe("Paginator component tests", () => {
     expect(prevButton.hasAttribute("disabled")).toBeTruthy();
     expect(nextButton.hasAttribute("disabled")).toBeFalsy();
     expect(lastButton.hasAttribute("disabled")).toBeFalsy();
+  });
+
+  test("itemsPerPage is 0 and showGoToPage is true", () => {
+    const { getByText, getAllByRole } = render(
+      <DxcPaginator itemsPerPage={0} itemsPerPageOptions={[5, 10, 15]} totalItems={27} showGoToPage />
+    );
+    expect(getByText("Items per page:")).toBeTruthy();
+    expect(getAllByRole("combobox")).toBeTruthy();
   });
 });

--- a/lib/src/paginator/Paginator.tsx
+++ b/lib/src/paginator/Paginator.tsx
@@ -18,7 +18,7 @@ const DxcPaginator = ({
   itemsPerPageFunction,
   tabIndex = 0,
 }: PaginatorPropsType): JSX.Element => {
-  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  const totalPages = itemsPerPage > 0 && Math.ceil(totalItems / itemsPerPage);
   const currentPageInternal = currentPage === -1 ? totalPages : currentPage;
   const minItemsPerPage =
     currentPageInternal === 1 || currentPageInternal === 0


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_
- [x] Build process is done without errors and all tests pass in `/lib` directory.
- [x] Self-reviewed the code prior to submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Description**
Paginator fails when `itemsPerPage` is `0` and `showGoToPage` is `true`, since it is making this operation `totalItems / itemsPerPage`. The result of this operation (`totalItems / 0`) is `Infinity`. So when it is trying to make `Array(Infinity)` it fails.

**Closes #1619**