### PR TITLE
Deprecate `name` prop in File input

### DIFF
--- a/lib/src/file-input/types.ts
+++ b/lib/src/file-input/types.ts
@@ -22,7 +22,7 @@ type FileData = {
 
 type CommonProps = {
   /**
-   * Name attribute.
+   * @deprecated Name attribute.
    */
   name?: string;
   /**

--- a/website/screens/components/file-input/code/FileInputCodePage.tsx
+++ b/website/screens/components/file-input/code/FileInputCodePage.tsx
@@ -1,4 +1,9 @@
-import { DxcFlex, DxcTable, DxcLink } from "@dxc-technology/halstack-react";
+import {
+  DxcFlex,
+  DxcTable,
+  DxcLink,
+  DxcGrid,
+} from "@dxc-technology/halstack-react";
 import QuickNavContainerLayout from "@/common/QuickNavContainerLayout";
 import QuickNavContainer from "@/common/QuickNavContainer";
 import Code from "@/common/Code";
@@ -26,7 +31,12 @@ const sections = [
           <tr>
             <td>name: string</td>
             <td></td>
-            <td>Name attribute.</td>
+            <td>
+              <DxcGrid gap="0.25rem" placeItems="start">
+                <StatusTag status="Deprecated">Deprecated</StatusTag>
+                Name attribute.
+              </DxcGrid>
+            </td>
           </tr>
           <tr>
             <td>mode: 'file' | 'filedrop' | 'dropzone'</td>


### PR DESCRIPTION
**Checklist**
- [ ] Build process is done without errors and all tests pass in the `/lib` directory.
- [ ] Self-reviewed the code before submitting.
- [ ] Meets accessibility standards.
- [ ] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Description**
Deprecating the `name` prop of the File Input in both types and documentation.

**Closes #1637**