### PR TITLE
Include README file into the library build

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "test": "jest --env=jsdom",
     "test:watch": "npm test -- --watch --coverage",
-    "build": "babel src --extensions .js,.jsx,.ts,.tsx --out-dir ../dist --copy-files --verbose && node ../scripts/build/copy-package.js && tsc ",
+    "build": "babel src --extensions .js,.jsx,.ts,.tsx --out-dir ../dist --copy-files --verbose && node ../scripts/build/copy-package.js && node ../scripts/build/copy-readme.js && tsc ",
     "build:watch": "babel src --watch --extensions .js,.jsx,.ts,.tsx --out-dir ../dist --copy-files --verbose",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"

--- a/scripts/build/copy-readme.js
+++ b/scripts/build/copy-readme.js
@@ -1,0 +1,3 @@
+const fs = require('fs');
+
+fs.createReadStream('../README.md').pipe(fs.createWriteStream('../dist/README.md'));


### PR DESCRIPTION
**Checklist**

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
Add the README.md of Halstack to the build of the library, so it appears on our npm [page](https://www.npmjs.com/package/@dxc-technology/halstack-react).

**Description**
Added `copy-readme.js` file to the `/scripts` folder and execute it in the build process.
