### PR TITLE
Typo in Dropdown's Usage page

### DIFF
--- a/website/screens/components/dropdown/usage/DropdownUsagePage.tsx
+++ b/website/screens/components/dropdown/usage/DropdownUsagePage.tsx
@@ -16,7 +16,7 @@ const sections = [
       <>
         <DxcParagraph>
           Dropdowns have a similar look and behavior to select components, the
-          the difference is that while select is only to collect user's data
+          difference is that while select is only to collect user's data
           into a form, dropdown can be used in a variety of scenarios.
         </DxcParagraph>
         <DxcBulletedList>


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.


**Description**
The word "the" was duplicated in a sentence in the Dropdown's usage page.


