### PR TITLE
Font-bold token was documented in the Spinner specs section

### DIFF
--- a/website/screens/components/spinner/specs/SpinnerSpecsPage.tsx
+++ b/website/screens/components/spinner/specs/SpinnerSpecsPage.tsx
@@ -232,7 +232,7 @@ const sections = [
                 <td>
                   <Code>font-bold</Code>
                 </td>
-                <td>600</td>
+                <td>700</td>
               </tr>
             </tbody>
           </DxcTable>


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
To change the value of the token assigned to spinner component.

**Description**
In the Specs of the Spinner component, it is described that the font-weight of the percentage is 600, which is not correct, as it is 700. The token displayed for that font-weight is correct once we change that value, as font-bold sets font weight as bold (700).

**Screenshots**

<img width="848" alt="Spinner typography specs" src="https://github.com/dxc-technology/halstack-react/assets/147498165/bd716e81-48cf-401e-804f-5e77f2455022">
<img width="1174" alt="halstack-typography-tokens" src="https://github.com/dxc-technology/halstack-react/assets/147498165/2ee97817-2d3a-4745-b70f-a4cfef3142a9">


