### PR TITLE
Incorrect value for font size our Progressbar label

### DIFF
--- a/website/screens/components/progress-bar/specs/ProgressBarSpecsPage.tsx
+++ b/website/screens/components/progress-bar/specs/ProgressBarSpecsPage.tsx
@@ -349,9 +349,9 @@ const sections = [
                 </td>
                 <td>Label</td>
                 <td>
-                  <Code>font-scale-02</Code>
+                  <Code>font-scale-01</Code>
                 </td>
-                <td>14px</td>
+                <td>12px</td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [ ] Build process is done without errors. All tests pass in the `/lib` directory.
- [ ] Self-reviewed the code before submitting.
- [ ] Meets accessibility standards.
- [ ] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Purpose**
Change the value of the label's font size in the specs section of the Progressbar component.

**Description**
The font size in our Progressbar component label was described as 14px, with its consequent token being font-scale-02. However, both in implementation and in our design kit, this value is 12px, with its token being font-scale-03. I'm proposing both changes so that our specs are aligned with what we have in the rest of our resources.

