### PR TITLE
Fixing Dialog focus modifying the page scroll

### DIFF
--- a/lib/src/dialog/Dialog.test.js
+++ b/lib/src/dialog/Dialog.test.js
@@ -242,7 +242,6 @@ describe("Dialog component: Focus lock tests", () => {
   });
 
   test("Focus gets trapped in the Dialog when there are not focusable elements inside until it is closed", () => {
-    const initialScrollPosition = window.scrollY;
     const { getAllByRole } = render(
       <>
         <DxcTextInput label="Name" />
@@ -261,6 +260,5 @@ describe("Dialog component: Focus lock tests", () => {
     fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
     fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
     expect(document.activeElement).not.toEqual(inputs[0]);
-    expect(window.scrollY).toEqual(initialScrollPosition);
   });
 });

--- a/lib/src/dialog/Dialog.test.js
+++ b/lib/src/dialog/Dialog.test.js
@@ -242,6 +242,7 @@ describe("Dialog component: Focus lock tests", () => {
   });
 
   test("Focus gets trapped in the Dialog when there are not focusable elements inside until it is closed", () => {
+    const initialScrollPosition = window.scrollY;
     const { getAllByRole } = render(
       <>
         <DxcTextInput label="Name" />
@@ -260,5 +261,6 @@ describe("Dialog component: Focus lock tests", () => {
     fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
     fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
     expect(document.activeElement).not.toEqual(inputs[0]);
+    expect(window.scrollY).toEqual(initialScrollPosition);
   });
 });


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Description**
The logic that handles focus and keypresses inside the `Dialog` component has been modified in order to prevent a bug with the page automatically scrolling when we reached a limit object.

**Additional context**
The new implementation for the FocusLock component seems to fix the issue. However I can think of certain edge cases that would need to be reviewed being:
- How to detect which one is the first focusable object in the `focusableElements` array **without actually focusing it**. Right now, the first and last are being considered the ones with index `0` and `length - 1`. (Is being in the `focusableElements` array a warranty that the item can be focused? If so, is it necessary that we use the `attemptFocus` function?)
- I have realized that the scroll check inside the testing section also passes with the previous version, which makes me wonder how can we properly check the case documented in the issue #1532

**Closes #1532**
