### PR TITLE
Added 100% width underline to NavTab

### DIFF
--- a/lib/src/common/variables.ts
+++ b/lib/src/common/variables.ts
@@ -506,6 +506,7 @@ export const componentTokens = {
     selectedIconColor: CoreTokens.color_grey_700,
     unselectedIconColor: CoreTokens.color_grey_700,
     disabledIconColor: CoreTokens.color_grey_500,
+    dividerThickness: "2px",
   },
   paginator: {
     backgroundColor: CoreTokens.color_grey_100,

--- a/lib/src/common/variables.ts
+++ b/lib/src/common/variables.ts
@@ -506,7 +506,6 @@ export const componentTokens = {
     selectedIconColor: CoreTokens.color_grey_700,
     unselectedIconColor: CoreTokens.color_grey_700,
     disabledIconColor: CoreTokens.color_grey_500,
-    dividerThickness: "2px",
   },
   paginator: {
     backgroundColor: CoreTokens.color_grey_100,

--- a/lib/src/nav-tabs/NavTabs.tsx
+++ b/lib/src/nav-tabs/NavTabs.tsx
@@ -77,15 +77,27 @@ const DxcNavTabs = ({ iconPosition = "top", tabIndex = 0, children }: NavTabsPro
     <ThemeProvider theme={colorsTheme.navTabs}>
       <NavTabsContainer onKeyDown={handleOnKeyDown} role="tablist" aria-label="Navigation tabs">
         <NavTabsContext.Provider value={contextValue}>{children}</NavTabsContext.Provider>
+        <Underline />
       </NavTabsContainer>
     </ThemeProvider>
   );
 };
 
+const Underline = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: ${(props) => props.theme.dividerThickness};
+  background-color: ${(props) => props.theme.dividerColor};
+  z-index: -1;
+`;
+
 DxcNavTabs.Tab = DxcTab;
 
 const NavTabsContainer = styled.div`
   display: flex;
+  position: relative;
 `;
 
 export default DxcNavTabs;

--- a/lib/src/nav-tabs/NavTabs.tsx
+++ b/lib/src/nav-tabs/NavTabs.tsx
@@ -88,7 +88,7 @@ const Underline = styled.div`
   bottom: 0;
   left: 0;
   width: 100%;
-  height: ${(props) => props.theme.dividerThickness};
+  height: 2px;
   background-color: ${(props) => props.theme.dividerColor};
   z-index: -1;
 `;

--- a/lib/src/nav-tabs/Tab.tsx
+++ b/lib/src/nav-tabs/Tab.tsx
@@ -91,7 +91,7 @@ const DxcTab = forwardRef(
 
 const TabContainer = styled.div<{ active: TabProps["active"] }>`
   align-items: stretch;
-  border-bottom: 2px solid ${(props) => (props.active ? props.theme.selectedUnderlineColor : props.theme.dividerColor)};
+  border-bottom: 2px solid ${(props) => (props.active ? props.theme.selectedUnderlineColor : 'transparent')};
   padding: 0.5rem;
 
   svg {

--- a/website/screens/common/TabsPageLayout.tsx
+++ b/website/screens/common/TabsPageLayout.tsx
@@ -22,7 +22,6 @@ const TabsPageLayout = ({ tabs }: TabsPageLayoutProps) => {
           </Link>
         ))}
       </DxcNavTabs>
-      <Divider />
     </TabsContainer>
   );
 };


### PR DESCRIPTION
**Checklist**

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.


**Description**
It has been decided that it is more appropiate for NavTabs component to always fill all the available space, that prevents ourselves from using "tricks" in order to achieve that.

**Screenshots**
![image](https://github.com/dxc-technology/halstack-react/assets/33158831/61902845-7278-4f2d-9f27-80e3e23177a6)



**Closes #1525**
