### PR TITLE
Fixed typo in RadioGroup

### DIFF
--- a/lib/src/radio-group/RadioGroup.tsx
+++ b/lib/src/radio-group/RadioGroup.tsx
@@ -147,7 +147,7 @@ const DxcRadioGroup = React.forwardRef<RefType, RadioGroupPropsType>(
             aria-invalid={error ? true : false}
             aria-errormessage={error ? errorId : undefined}
             aria-required={!disabled && !readOnly && !optional}
-            aria-readOnly={readOnly}
+            aria-readonly={readOnly}
             aria-orientation={stacking === "column" ? "vertical" : "horizontal"}
           >
             <ValueInput name={name} disabled={disabled} value={value ?? innerValue ?? ""} readOnly />


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Description**
`aria-readonly` attribute was state as `aria-readOnly`, so it was throwing a warning
