### PR TITLE
Added autoclose exempt label for GitHub Bot

### DIFF
--- a/.github/workflows/inactive-issues.yml
+++ b/.github/workflows/inactive-issues.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/stale@v5
         with:
@@ -17,4 +16,5 @@ jobs:
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 15 days with no activity. If there are no further updates or modifications within the next 15 days, it will be automatically closed."
           close-issue-message: "This issue has been closed as it has been inactive for 15 days since being marked as stale."
+          exempt-issue-labels: 'non-closable'
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Description**
Now, issues labeled with "non-closable" are not marked as stale or get automatically closed.
