### PR TITLE
Avoid text wrapping in the badge

### DIFF
--- a/lib/src/badge/Badge.tsx
+++ b/lib/src/badge/Badge.tsx
@@ -154,6 +154,7 @@ const LabelContainer = styled.span<{ size: BadgePropsType["size"] }>`
   font-family: ${CoreTokens.type_sans};
   font-size: ${(props) => sizeMap[props.size].fontSize};
   font-weight: ${CoreTokens.type_semibold};
+  white-space: nowrap;
 `;
 
 export default DxcBadge;


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Purpose**
When the badge is used in a small dynamic space like the columns of a table the badge wraps the text. 

**Screenshots**
![image](https://github.com/dxc-technology/halstack-react/assets/12238686/30a43c34-2bd9-4bf5-9fb4-a8f23ada662a)

