### PR TITLE
Fix typo in Accordion token

### DIFF
--- a/lib/src/accordion/Accordion.tsx
+++ b/lib/src/accordion/Accordion.tsx
@@ -188,7 +188,7 @@ const AccordionLabel = styled.span`
 const IconContainer = styled.span<{ disabled: AccordionPropsType["disabled"] }>`
   display: flex;
   margin-left: ${(props) => props.theme.iconMarginLeft};
-  margin-right: ${(props) => props.theme.iconMarginRigth};
+  margin-right: ${(props) => props.theme.iconMarginRight};
   color: ${(props) => (props.disabled ? props.theme.disabledIconColor : props.theme.iconColor)};
 
   svg,

--- a/lib/src/common/variables.ts
+++ b/lib/src/common/variables.ts
@@ -38,7 +38,7 @@ export const componentTokens = {
     disabledIconColor: CoreTokens.color_grey_500,
     iconSize: "24px",
     iconMarginLeft: "0px",
-    iconMarginRigth: "12px",
+    iconMarginRight: "12px",
     accordionGroupSeparatorBorderColor: CoreTokens.color_grey_200_a,
     accordionGroupSeparatorBorderThickness: "1px",
     accordionGroupSeparatorBorderRadius: "0px",

--- a/website/screens/common/themes/advanced-theme.json
+++ b/website/screens/common/themes/advanced-theme.json
@@ -36,7 +36,7 @@
     "disabledIconColor": "#999999",
     "iconSize": "24px",
     "iconMarginLeft": "0px",
-    "iconMarginRigth": "12px",
+    "iconMarginRight": "12px",
     "accordionGroupSeparatorBorderColor": "#0000001a",
     "accordionGroupSeparatorBorderThickness": "1px",
     "accordionGroupSeparatorBorderRadius": "0px",

--- a/website/screens/theme-generator/themes/schemas/advanced.schema.json
+++ b/website/screens/theme-generator/themes/schemas/advanced.schema.json
@@ -35,7 +35,7 @@
     "iconColor": "color",
     "iconSize": "length",
     "iconMarginLeft": "length",
-    "iconMarginRigth": "length",
+    "iconMarginRight": "length",
     "disabledIconColor": "color",
     "accordionGroupSeparatorBorderColor": "color",
     "accordionGroupSeparatorBorderThickness": "bWidth",


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Description**
Fix typo in a token from the Accordion component. Replace `iconMarginRigth` with `iconMarginRight`.

**Closes #1763**
