### PR TITLE
Increased timeout fileinput

### DIFF
--- a/lib/src/file-input/FileInput.test.js
+++ b/lib/src/file-input/FileInput.test.js
@@ -122,7 +122,7 @@ describe("FileInput component tests", () => {
       expect(getByText("file1.png")).toBeTruthy();
       expect(getByText("file2.txt")).toBeTruthy();
       expect(getByText("Error message")).toBeTruthy();
-    });
+    }, { timeout: 2500 });
   });
 
   test("Renders non-duplicated items passed in value when multiple file input", async () => {
@@ -152,7 +152,7 @@ describe("FileInput component tests", () => {
           preview: "draft",
         },
       ]);
-    });
+    }, { timeout: 2500 });
   });
 
   test("Renders file items when single file input", async () => {
@@ -170,7 +170,7 @@ describe("FileInput component tests", () => {
       expect(getByText("file1.png")).toBeTruthy();
       expect(getByText("file2.txt")).toBeTruthy();
       expect(getByText("Error message")).toBeTruthy();
-    });
+    }, { timeout: 2500 });
   });
 
   test("Add file item when single file input", async () => {
@@ -197,7 +197,7 @@ describe("FileInput component tests", () => {
           preview: "draft",
         },
       ]);
-    });
+    }, { timeout: 2500 });
   });
 
   test("Renders file items and delete one file", async () => {
@@ -223,7 +223,7 @@ describe("FileInput component tests", () => {
           preview: "draft",
         },
       ]);
-    });
+    }, { timeout: 2500 });
   });
 
   test("CallbackFile is correctly called", async () => {
@@ -256,7 +256,7 @@ describe("FileInput component tests", () => {
           preview: "draft",
         },
       ]);
-    });
+    }, { timeout: 2500 });
   });
 
   test("Callback called correctly when a file size does not comply minSize or maxSize", async () => {
@@ -291,6 +291,6 @@ describe("FileInput component tests", () => {
           preview: "draft",
         },
       ]);
-    });
+    }, { timeout: 2500 });
   });
 });


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [ ] Build process is done without errors. All tests pass in the `/lib` directory.
- [ ] Self-reviewed the code before submitting.
- [ ] Meets accessibility standards.
- [ ] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Description**
I realised that, in local environment, when running all the functional tests at once (using npm run test), a timeout error was sometimes being thrown at `FileInput.test.js`. The default timer for `waitFor` is set to 1000ms, so increasing it to 2500ms allows for more consistency when running tests. This should not be the final approach for this due to existing room for improvement of functional tests efficiency (wrapping tests inside act as recommended, configuring parallel execution, identifying and solving specific bottlenecks...) However, I considered this to be an non-costly and appropiate workaround for now.
