### PR TITLE
Fix file input delete styles

### DIFF
--- a/lib/src/file-input/FileItem.tsx
+++ b/lib/src/file-input/FileItem.tsx
@@ -56,7 +56,11 @@ const FileItem = ({
               <DxcIcon icon="close" />
             </DeleteFileAction>
           </DxcFlex>
-          {error && !singleFileMode && <ErrorMessage role="alert" aria-live="assertive">{error}</ErrorMessage>}
+          {error && !singleFileMode && (
+            <ErrorMessage role="alert" aria-live="assertive">
+              {error}
+            </ErrorMessage>
+          )}
         </FileItemContent>
       </MainContainer>
     </ThemeProvider>
@@ -145,6 +149,7 @@ const DeleteFileAction = styled.button`
   display: flex;
   flex-wrap: wrap;
   align-content: center;
+  justify-content: center;
   height: 24px;
   width: 24px;
   font-size: 1rem;


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [ ] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Description**
File input's delete icon was not centered. Added `justify-content: center` to the button.

**Screenshots**
Before:
![image](https://github.com/dxc-technology/halstack-react/assets/10975289/761a47c4-dd6e-42d1-8d20-be6978a454a3)

Now:
![image](https://github.com/dxc-technology/halstack-react/assets/10975289/c4b6ff94-d952-4dbb-a161-519373fb7eff)

**Closes #1994**
