### PR TITLE
Reverted back Open sans import due to issues with globalStyles

### DIFF
--- a/lib/src/HalstackContext.tsx
+++ b/lib/src/HalstackContext.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import Color from "color";
-import { createGlobalStyle } from "styled-components";
+import styled from "styled-components";
 import {
   AdvancedTheme,
   OpinionatedTheme,
@@ -395,19 +395,20 @@ type HalstackProviderPropsType = {
 const HalstackProvider = ({ theme, advancedTheme, labels, children }: HalstackProviderPropsType): JSX.Element => {
   const parsedTheme = useMemo(
     () => (theme ? parseTheme(theme) : advancedTheme ? parseAdvancedTheme(advancedTheme) : componentTokens),
-    [theme, advancedTheme],
+    [theme, advancedTheme]
   );
   const parsedLabels = useMemo(() => (labels ? parseLabels(labels) : defaultTranslatedComponentLabels), [labels]);
 
   return (
-    <HalstackContext.Provider value={parsedTheme}>
-      <GlobalStyle />
-      <HalstackLanguageContext.Provider value={parsedLabels}>{children}</HalstackLanguageContext.Provider>
-    </HalstackContext.Provider>
+    <Halstack>
+      <HalstackContext.Provider value={parsedTheme}>
+        <HalstackLanguageContext.Provider value={parsedLabels}>{children}</HalstackLanguageContext.Provider>
+      </HalstackContext.Provider>
+    </Halstack>
   );
 };
 
-const GlobalStyle = createGlobalStyle`
+const Halstack = styled.div`
   @import url("https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap");
 `;
 


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
A new warning appeared with this change and it seems that it was causing issues in some apps with font styles.

![image](https://github.com/dxc-technology/halstack-react/assets/12238686/c23795b4-899e-4916-a134-b471e5a3da84)
