### PR TITLE
Opinionated theme support added to the actionIcon in the table

### DIFF
--- a/apps/website/screens/principles/themes/ThemesPage.tsx
+++ b/apps/website/screens/principles/themes/ThemesPage.tsx
@@ -1124,6 +1124,18 @@ const sections = [
                         <td>Base color</td>
                         <td>
                           <Code>headerBackgroundColor</Code>
+                          <br />
+                          <br />
+                          <Code>actionIconColor</Code>
+                          <br />
+                          <br />
+                          <Code>hoverActionIconColor</Code>
+                          <br />
+                          <br />
+                          <Code>focusActionIconColor</Code>
+                          <br />
+                          <br />
+                          <Code>activeActionIconColor</Code>
                         </td>
                       </tr>
                       <tr>

--- a/packages/lib/src/HalstackContext.tsx
+++ b/packages/lib/src/HalstackContext.tsx
@@ -289,6 +289,10 @@ const parseTheme = (theme: DeepPartial<OpinionatedTheme>): AdvancedTheme => {
   tableTokens.headerFontColor = theme?.table?.headerFontColor ?? tableTokens.headerFontColor;
   tableTokens.dataFontColor = theme?.table?.cellFontColor ?? tableTokens.dataFontColor;
   tableTokens.sortIconColor = theme?.table?.headerFontColor ?? tableTokens.sortIconColor;
+  tableTokens.actionIconColor = theme?.table?.baseColor ?? tableTokens.actionIconColor;
+  tableTokens.hoverActionIconColor = theme?.table?.baseColor ?? tableTokens.hoverActionIconColor;
+  tableTokens.focusActionIconColor = theme?.table?.baseColor ?? tableTokens.focusActionIconColor;
+  tableTokens.activeActionIconColor = theme?.table?.baseColor ?? tableTokens.activeActionIconColor;
 
   const tabsTokens = componentTokensCopy.tabs;
   tabsTokens.selectedFontColor = theme?.tabs?.baseColor ?? tabsTokens.selectedFontColor;


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
Added opinionated theme support to the actionIcon in the table.

![image](https://github.com/user-attachments/assets/a2072ff5-530c-4cda-86e2-1c408199075b)


Closes #2047 