### PR TITLE
Changed `0` for `0rem / 0px` to achieve better consistency in docs

### DIFF
--- a/apps/website/screens/components/box/specs/BoxSpecsPage.tsx
+++ b/apps/website/screens/components/box/specs/BoxSpecsPage.tsx
@@ -107,7 +107,7 @@ const sections = [
                 <td>
                   <Code>border-width-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>

--- a/apps/website/screens/components/button/specs/ButtonSpecsPage.tsx
+++ b/apps/website/screens/components/button/specs/ButtonSpecsPage.tsx
@@ -394,7 +394,7 @@ const sections = [
                     <td>
                       <Code>border-width-0</Code>
                     </td>
-                    <td>0</td>
+                    <td>0rem / 0px</td>
                   </tr>
                   <tr>
                     <td>
@@ -796,7 +796,7 @@ const sections = [
                     <td>
                       <Code>border-width-0</Code>
                     </td>
-                    <td>0</td>
+                    <td>0rem / 0px</td>
                   </tr>
                   <tr>
                     <td>

--- a/apps/website/screens/components/card/specs/CardSpecsPage.tsx
+++ b/apps/website/screens/components/card/specs/CardSpecsPage.tsx
@@ -111,7 +111,7 @@ const sections = [
                 <td>
                   <Code>border-width-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>

--- a/apps/website/screens/components/chip/specs/ChipSpecsPage.tsx
+++ b/apps/website/screens/components/chip/specs/ChipSpecsPage.tsx
@@ -275,7 +275,7 @@ const sections = [
                 <td>
                   <Code>spacing-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>
@@ -285,7 +285,7 @@ const sections = [
                 <td>
                   <Code>spacing-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>
@@ -322,7 +322,7 @@ const sections = [
                 <td>
                   <Code>border-width-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>

--- a/apps/website/screens/components/dialog/specs/DialogSpecsPage.tsx
+++ b/apps/website/screens/components/dialog/specs/DialogSpecsPage.tsx
@@ -221,7 +221,7 @@ const sections = [
                   <td>
                     <Code>border-width-0</Code>
                   </td>
-                  <td>0</td>
+                  <td>0rem / 0px</td>
                 </tr>
                 <tr>
                   <td>

--- a/apps/website/screens/components/dropdown/specs/DropdownSpecsPage.tsx
+++ b/apps/website/screens/components/dropdown/specs/DropdownSpecsPage.tsx
@@ -368,7 +368,7 @@ const sections = [
                 <td>
                   <Code>border-width-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>
@@ -398,7 +398,7 @@ const sections = [
                 <td>
                   <Code>border-width-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>

--- a/apps/website/screens/components/progress-bar/specs/ProgressBarSpecsPage.tsx
+++ b/apps/website/screens/components/progress-bar/specs/ProgressBarSpecsPage.tsx
@@ -392,7 +392,7 @@ const sections = [
                 <td>
                   <Code>border-width-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>

--- a/apps/website/screens/components/slider/specs/SliderSpecsPage.tsx
+++ b/apps/website/screens/components/slider/specs/SliderSpecsPage.tsx
@@ -610,7 +610,7 @@ const sections = [
                 <td>
                   <Code>border-width-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>
@@ -640,7 +640,7 @@ const sections = [
                 <td>
                   <Code>border-width-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>

--- a/apps/website/screens/components/switch/specs/SwitchSpecsPage.tsx
+++ b/apps/website/screens/components/switch/specs/SwitchSpecsPage.tsx
@@ -335,7 +335,7 @@ const sections = [
                 <td>
                   <Code>border-width-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>
@@ -365,7 +365,7 @@ const sections = [
                 <td>
                   <Code>border-width-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>

--- a/apps/website/screens/components/toggle-group/specs/ToggleGroupSpecsPage.tsx
+++ b/apps/website/screens/components/toggle-group/specs/ToggleGroupSpecsPage.tsx
@@ -515,7 +515,7 @@ const sections = [
                 <td>
                   <Code>border-width-0</Code>
                 </td>
-                <td>0</td>
+                <td>0rem / 0px</td>
               </tr>
               <tr>
                 <td>

--- a/apps/website/screens/components/typography/specs/TypographySpecsPage.tsx
+++ b/apps/website/screens/components/typography/specs/TypographySpecsPage.tsx
@@ -304,7 +304,7 @@ const sections = [
                   <td>
                     <Code>font-tracking-normal</Code>
                   </td>
-                  <td>0</td>
+                  <td>0rem / 0px</td>
                 </tr>
                 <tr>
                   <td>


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [ ] Build process is done without errors. All tests pass in the `/lib` directory.
- [ ] Self-reviewed the code before submitting.
- [ ] Meets accessibility standards.
- [ ] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Description**
As spotted in #2042, the units for spacing are not added when the value is 0. That would be appropiate to achieve a better consistency within the components' documentation.
