### PR TITLE
Fixed viewport not being reset after exiting responsive story

### DIFF
--- a/packages/lib/.storybook/preview.tsx
+++ b/packages/lib/.storybook/preview.tsx
@@ -12,6 +12,9 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    viewport: {
+      defaultViewport: "reset",
+    },
     a11y: {
       config: {
         rules: disabledRules.map((ruleId) => ({ id: ruleId, enabled: false })),


### PR DESCRIPTION
**Checklist**

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Description**
An unexpected behavior has been found. When inside the stories of a component that contains responsive behavior for small screens (for example iphonex), it doesn't matter if you go to a non-responsive story. The viewport mode that was triggered will remain. 

**Additional context**
https://github.com/storybookjs/storybook/issues/27073#issue-2287234733
