### PR TITLE
Added fix for whitespaces not displaying in filename

### DIFF
--- a/packages/lib/src/file-input/FileInput.stories.tsx
+++ b/packages/lib/src/file-input/FileInput.stories.tsx
@@ -24,10 +24,17 @@ const file4 = new File(["file4"], "file4file4file4file4file4file4file4file4file4
 const file5 = new File(["file5"], "file5file5file5file5file5file5file5file5file5.mp4", {
   type: "video",
 });
+const fileWithSpaces = new File(["fileSpaces"], "  f i l e     s  p    a    c  e s.png", { type: "image/png" });
 
 const fileExample = [
   {
     file: file1,
+  },
+];
+
+const fileWithSpacesExample = [
+  {
+    file: fileWithSpaces,
   },
 ];
 
@@ -130,6 +137,16 @@ export const Chromatic = () => (
         label="File input"
         helperText="Please select files"
         value={fileExample}
+        multiple={false}
+        callbackFile={() => {}}
+      />
+    </ExampleContainer>
+    <ExampleContainer>
+      <Title title="Single file (with spaces)" theme="light" level={4} />
+      <DxcFileInput
+        label="File input"
+        helperText="Please select files"
+        value={fileWithSpacesExample}
         multiple={false}
         callbackFile={() => {}}
       />

--- a/packages/lib/src/file-input/FileItem.tsx
+++ b/packages/lib/src/file-input/FileItem.tsx
@@ -125,7 +125,7 @@ const FileName = styled.span`
   font-size: ${(props) => props.theme.fileItemFontSize};
   font-weight: ${(props) => props.theme.fileItemFontWeight};
   line-height: ${(props) => props.theme.fileItemLineHeight};
-  white-space: nowrap;
+  white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
 `;


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [ ] Build process is done without errors. All tests pass in the `/lib` directory.
- [ ] Self-reviewed the code before submitting.
- [ ] Meets accessibility standards.
- [ ] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Description**
`FileItems` inside `FileInput` were not displaying their `fileName` in a correct way, as the `no-wrap` option for `white-space` does indeed collapse consecutive spaces into one. 

**Closes #2106**
