### PR TITLE
Added controlled behavior to `Tooltip`

### DIFF
--- a/apps/website/screens/components/tooltip/code/TooltipCodePage.tsx
+++ b/apps/website/screens/components/tooltip/code/TooltipCodePage.tsx
@@ -41,6 +41,38 @@ const sections = [
             <td>-</td>
           </tr>
           <tr>
+            <td>open</td>
+            <td>
+              <TableCode>boolean</TableCode>
+            </td>
+            <td>If true, the component will be displayed.</td>
+            <td>-</td>
+          </tr>
+          <tr>
+            <td>defaultOpen</td>
+            <td>
+              <TableCode>boolean</TableCode>
+            </td>
+            <td>Initial status of the tooltip, only when it is uncontrolled.</td>
+            <td>-</td>
+          </tr>
+          <tr>
+            <td>onOpen</td>
+            <td>
+              <TableCode>{"() => void"}</TableCode>
+            </td>
+            <td>This function will be called when the tooltip starts being shown.</td>
+            <td>-</td>
+          </tr>
+          <tr>
+            <td>onClose</td>
+            <td>
+              <TableCode>{"() => void"}</TableCode>
+            </td>
+            <td>This function will be called when the tooltip stops being shown.</td>
+            <td>-</td>
+          </tr>
+          <tr>
             <td>children</td>
             <td>
               <TableCode>React.ReactNode</TableCode>

--- a/packages/lib/src/tooltip/Tooltip.stories.tsx
+++ b/packages/lib/src/tooltip/Tooltip.stories.tsx
@@ -5,6 +5,8 @@ import DxcButton from "../button/Button";
 import DxcFlex from "../flex/Flex";
 import DxcInset from "../inset/Inset";
 import DxcTooltip from "./Tooltip";
+import { useState } from "react";
+import useEffect from "react";
 
 export default {
   title: "Tooltip",
@@ -42,7 +44,7 @@ const TopTooltip = () => (
     <Title title="Top tooltip" theme="light" level={4} />
     <ExampleContainer>
       <DxcInset top="3rem">
-        <DxcTooltip label="Tooltip Test" position="top">
+        <DxcTooltip label="Tooltip Test" position="top" onClose={() => {console.log("CLOSE")}} onOpen={() => {console.log("OPEN")}}>
           <DxcButton label="Hoverable button" />
         </DxcTooltip>
       </DxcInset>
@@ -73,6 +75,38 @@ const RightTooltip = () => (
     </ExampleContainer>
   </>
 );
+
+const ControlledTooltip = () => {
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+    setTimeout(() => {
+      setOpen(false);
+    }, 2000);
+  };
+
+  return (
+    <>
+      <Title title="Controlled tooltip" theme="light" level={4} />
+      <ExampleContainer>
+        <DxcButton label="Trigger tooltip here" onClick={handleOpen} />
+        <DxcTooltip
+          label="Tooltip Test"
+          open={open}
+          onOpen={() => {
+            console.log("Tooltip opened");
+          }}
+          onClose={() => {
+            console.log("Tooltip closed");
+          }}
+        >
+          <DxcButton label="Button with controlled tooltip" />
+        </DxcTooltip>
+      </ExampleContainer>
+    </>
+  );
+};
 
 export const Chromatic = Tooltip.bind({});
 Chromatic.play = async ({ canvasElement }) => {
@@ -107,4 +141,11 @@ TooltipPositionRight.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
   const button = canvas.getByRole("button");
   await userEvent.hover(button);
+};
+
+export const TooltipControlled = ControlledTooltip.bind({});
+TooltipControlled.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const button = canvas.getAllByRole("button")[0];
+  await userEvent.click(button);
 };

--- a/packages/lib/src/tooltip/Tooltip.stories.tsx
+++ b/packages/lib/src/tooltip/Tooltip.stories.tsx
@@ -44,7 +44,16 @@ const TopTooltip = () => (
     <Title title="Top tooltip" theme="light" level={4} />
     <ExampleContainer>
       <DxcInset top="3rem">
-        <DxcTooltip label="Tooltip Test" position="top" onClose={() => {console.log("CLOSE")}} onOpen={() => {console.log("OPEN")}}>
+        <DxcTooltip
+          label="Tooltip Test"
+          position="top"
+          onClose={() => {
+            console.log("CLOSE");
+          }}
+          onOpen={() => {
+            console.log("OPEN");
+          }}
+        >
           <DxcButton label="Hoverable button" />
         </DxcTooltip>
       </DxcInset>
@@ -90,19 +99,21 @@ const ControlledTooltip = () => {
     <>
       <Title title="Controlled tooltip" theme="light" level={4} />
       <ExampleContainer>
-        <DxcButton label="Trigger tooltip here" onClick={handleOpen} />
-        <DxcTooltip
-          label="Tooltip Test"
-          open={open}
-          onOpen={() => {
-            console.log("Tooltip opened");
-          }}
-          onClose={() => {
-            console.log("Tooltip closed");
-          }}
-        >
-          <DxcButton label="Button with controlled tooltip" />
-        </DxcTooltip>
+        <DxcFlex gap={"1rem"}>
+          <DxcButton label="Trigger tooltip here" onClick={handleOpen} />
+          <DxcTooltip
+            label="Tooltip Test"
+            open={open}
+            onOpen={() => {
+              console.log("Tooltip opened");
+            }}
+            onClose={() => {
+              console.log("Tooltip closed");
+            }}
+          >
+            <DxcButton label="Button with controlled tooltip" />
+          </DxcTooltip>
+        </DxcFlex>
       </ExampleContainer>
     </>
   );

--- a/packages/lib/src/tooltip/Tooltip.test.tsx
+++ b/packages/lib/src/tooltip/Tooltip.test.tsx
@@ -53,4 +53,40 @@ describe("Tooltip component tests", () => {
       expect(tooltipElement).toBeFalsy();
     });
   });
+
+  test("Calls correct function (onOpen/onClose) in controlled mode", async () => {
+    const onOpen = jest.fn();
+    const onClose = jest.fn();
+    const { rerender, queryByRole } = render(
+      <DxcTooltip label="Tooltip Test" open={false} onOpen={onOpen} onClose={onClose}>
+        <DxcButton label="Button with controlled tooltip" />
+      </DxcTooltip>
+    );
+
+    await waitFor(() => {
+      const tooltipElement = queryByRole("tooltip");
+      expect(tooltipElement).toBeFalsy();
+    });
+
+    rerender(
+      <DxcTooltip label="Tooltip Test" open={true} onOpen={onOpen} onClose={onClose}>
+        <DxcButton label="Button with controlled tooltip" />
+      </DxcTooltip>
+    );
+
+    await screen.findByRole("tooltip", { name: "Tooltip Test" });
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <DxcTooltip label="Tooltip Test" open={false} onOpen={onOpen} onClose={onClose}>
+        <DxcButton label="Button with controlled tooltip" />
+      </DxcTooltip>
+    );
+
+    await waitFor(() => {
+      const tooltipElement = queryByRole("tooltip");
+      expect(tooltipElement).toBeFalsy();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/lib/src/tooltip/Tooltip.tsx
+++ b/packages/lib/src/tooltip/Tooltip.tsx
@@ -4,6 +4,7 @@ import TooltipPropsType, { TooltipWrapperProps } from "./types";
 import { createContext, useContext } from "react";
 import { Root, Trigger, Portal, Arrow, Content } from "@radix-ui/react-tooltip";
 import { Provider } from "@radix-ui/react-tooltip";
+import { useEffect } from "react";
 
 const TooltipTriggerContainer = styled.div`
   position: relative;
@@ -109,15 +110,34 @@ export const Tooltip = ({
   label,
   hasAdditionalContainer = false,
   position = "bottom",
+  open,
+  defaultOpen = false,
+  onOpen,
+  onClose,
   children,
 }: { hasAdditionalContainer?: boolean } & TooltipPropsType): JSX.Element => {
   const hasTooltip = useContext(TooltipContext);
+
+  useEffect(() => {
+    if (open !== undefined) {
+      open ? onOpen?.() : onClose?.();
+    }
+  }, [open]);
 
   return (
     <TooltipContext.Provider value={true}>
       {label && !hasTooltip ? (
         <Provider delayDuration={300}>
-          <Root>
+          <Root
+            open={open}
+            defaultOpen={defaultOpen}
+            onOpenChange={(status) => {
+              // Only works for uncontrolled mode
+              if (open === undefined) {
+                status ? onOpen?.() : onClose?.();
+              }
+            }}
+          >
             <Trigger asChild>
               {hasAdditionalContainer ? <TooltipTriggerContainer>{children}</TooltipTriggerContainer> : children}
             </Trigger>

--- a/packages/lib/src/tooltip/Tooltip.tsx
+++ b/packages/lib/src/tooltip/Tooltip.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import CoreTokens from "../common/coreTokens";
 import TooltipPropsType, { TooltipWrapperProps } from "./types";
-import { createContext, useContext } from "react";
+import { createContext, useContext, useState } from "react";
 import { Root, Trigger, Portal, Arrow, Content } from "@radix-ui/react-tooltip";
 import { Provider } from "@radix-ui/react-tooltip";
 import { useEffect } from "react";
@@ -111,33 +111,41 @@ export const Tooltip = ({
   hasAdditionalContainer = false,
   position = "bottom",
   open,
-  defaultOpen = false,
+  defaultOpen,
   onOpen,
   onClose,
   children,
 }: { hasAdditionalContainer?: boolean } & TooltipPropsType): JSX.Element => {
   const hasTooltip = useContext(TooltipContext);
-
+  const [isFirstRender, setIsFirstRender] = useState(true);
   useEffect(() => {
     if (open !== undefined) {
-      open ? onOpen?.() : onClose?.();
+      if (isFirstRender) {
+        setIsFirstRender(false);
+      } else {
+        if (open) {
+          onOpen?.();
+        } else {
+          onClose?.();
+        }
+      }
     }
   }, [open]);
+
+  const handleOpenChange = (status: boolean) => {
+    if(status) {
+      onOpen?.();
+    }
+    else {
+      onClose?.()
+    }
+  };
 
   return (
     <TooltipContext.Provider value={true}>
       {label && !hasTooltip ? (
         <Provider delayDuration={300}>
-          <Root
-            open={open}
-            defaultOpen={defaultOpen}
-            onOpenChange={(status) => {
-              // Only works for uncontrolled mode
-              if (open === undefined) {
-                status ? onOpen?.() : onClose?.();
-              }
-            }}
-          >
+          <Root open={open} defaultOpen={defaultOpen} onOpenChange={open === undefined ? handleOpenChange : undefined}>
             <Trigger asChild>
               {hasAdditionalContainer ? <TooltipTriggerContainer>{children}</TooltipTriggerContainer> : children}
             </Trigger>

--- a/packages/lib/src/tooltip/types.tsx
+++ b/packages/lib/src/tooltip/types.tsx
@@ -1,30 +1,3 @@
-// type Props = {
-//   /**
-//    * Preferred position for displaying the tooltip. It may adjust automatically based on available space.
-//    */
-//   position?: "bottom" | "top" | "left" | "right";
-//   /**
-//    * Text to be displayed inside the tooltip.
-//    */
-//   label: string;
-//   /**
-//    * If true, the component will be displayed.
-//    */
-//   open?: boolean;
-//   /**
-//    * This function will be called when the tooltip starts being shown.
-//    */
-//   onOpen?: () => void;
-//   /**
-//    * This function will be called when the tooltip stops being shown.
-//    */
-//   onClose?: () => void;
-//   /**
-//    * Content in which the Tooltip will be displayed.
-//    */
-//   children: React.ReactNode;
-// };
-
 type CommonProps = {
   /**
    * Preferred position for displaying the tooltip. It may adjust automatically based on available space.
@@ -38,6 +11,14 @@ type CommonProps = {
    * Content in which the Tooltip will be displayed.
    */
   children: React.ReactNode;
+  /**
+   * This function will be called when the tooltip starts being shown.
+   */
+  onOpen?: () => void;
+  /**
+   * This function will be called when the tooltip stops being shown.
+   */
+  onClose?: () => void;
 };
 
 type ControlledProps = {
@@ -49,14 +30,6 @@ type ControlledProps = {
    * If true, the component will be displayed.
    */
   open: boolean;
-  /**
-   * This function will be called when the tooltip starts being shown.
-   */
-  onOpen?: () => void;
-  /**
-   * This function will be called when the tooltip stops being shown.
-   */
-  onClose?: () => void;
 };
 
 type UnControlledProps = {
@@ -68,14 +41,6 @@ type UnControlledProps = {
    * If true, the component will be displayed.
    */
   open?: never;
-  /**
-   * This function will be called when the tooltip starts being shown.
-   */
-  onOpen?: () => void;
-  /**
-   * This function will be called when the tooltip stops being shown.
-   */
-  onClose?: () => void;
 };
 
 type Props = CommonProps & (ControlledProps | UnControlledProps);

--- a/packages/lib/src/tooltip/types.tsx
+++ b/packages/lib/src/tooltip/types.tsx
@@ -1,4 +1,31 @@
-type Props = {
+// type Props = {
+//   /**
+//    * Preferred position for displaying the tooltip. It may adjust automatically based on available space.
+//    */
+//   position?: "bottom" | "top" | "left" | "right";
+//   /**
+//    * Text to be displayed inside the tooltip.
+//    */
+//   label: string;
+//   /**
+//    * If true, the component will be displayed.
+//    */
+//   open?: boolean;
+//   /**
+//    * This function will be called when the tooltip starts being shown.
+//    */
+//   onOpen?: () => void;
+//   /**
+//    * This function will be called when the tooltip stops being shown.
+//    */
+//   onClose?: () => void;
+//   /**
+//    * Content in which the Tooltip will be displayed.
+//    */
+//   children: React.ReactNode;
+// };
+
+type CommonProps = {
   /**
    * Preferred position for displaying the tooltip. It may adjust automatically based on available space.
    */
@@ -12,6 +39,46 @@ type Props = {
    */
   children: React.ReactNode;
 };
+
+type ControlledProps = {
+  /**
+   * Initial status of the tooltip, only when it is uncontrolled.
+   */
+  defaultOpen?: never;
+  /**
+   * If true, the component will be displayed.
+   */
+  open: boolean;
+  /**
+   * This function will be called when the tooltip starts being shown.
+   */
+  onOpen?: () => void;
+  /**
+   * This function will be called when the tooltip stops being shown.
+   */
+  onClose?: () => void;
+};
+
+type UnControlledProps = {
+  /**
+   * Initial status of the tooltip, only when it is uncontrolled.
+   */
+  defaultOpen?: boolean;
+  /**
+   * If true, the component will be displayed.
+   */
+  open?: never;
+  /**
+   * This function will be called when the tooltip starts being shown.
+   */
+  onOpen?: () => void;
+  /**
+   * This function will be called when the tooltip stops being shown.
+   */
+  onClose?: () => void;
+};
+
+type Props = CommonProps & (ControlledProps | UnControlledProps);
 
 export type TooltipWrapperProps = {
   condition?: boolean;


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [ ] Build process is done without errors. All tests pass in the `/lib` directory.
- [ ] Self-reviewed the code before submitting.
- [ ] Meets accessibility standards.
- [ ] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Purpose**
We didn't have a way to have control over the tooltip display, We don't have to reduce it to be opened on hover and this will help us cover a lot of possible use cases in the future.