### PR TITLE
Fixed underline issue within `Tabs`

### DIFF
--- a/packages/lib/src/tabs/Tabs.tsx
+++ b/packages/lib/src/tabs/Tabs.tsx
@@ -93,7 +93,7 @@ const DxcTabs = ({
       setTotalTabsWidth(refTabList.current.firstElementChild?.offsetWidth);
       setMinHeightTabs(refTabList?.current?.offsetHeight + 1);
     }
-  }, [refTabList]);
+  }, []);
 
   const contextValue = useMemo(() => {
     const focusedChild = childrenArray[innerFocusIndex];


### PR DESCRIPTION
**Checklist**

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Description**
Under certain interactions, the underline for the active item would move down until not being shown at all.

**Additional context**
It has been happening since `DxcTabs` API was refactorized to use compound component. A change in the dependency array to calculate the width and height was causing this problem.

**Closes #2110**
