### PR TITLE
Adding Material Icons as an `@import` to the build using `injectStyles`

### DIFF
--- a/packages/lib/.storybook/preview.tsx
+++ b/packages/lib/.storybook/preview.tsx
@@ -31,7 +31,7 @@ const preview: Preview = {
 };
 
 const Container = styled.div`
-  @import url("https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:FILL@0..1");
+  @import url("https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap&family=Material+Symbols+Outlined:FILL@0..1");
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
     "Droid Sans", "Helvetica Neue", sans-serif;
 `;

--- a/packages/lib/.storybook/preview.tsx
+++ b/packages/lib/.storybook/preview.tsx
@@ -23,11 +23,9 @@ const preview: Preview = {
   },
   decorators: [
     (Story) => (
-      <HalstackProvider>
-        <Container>
-          <Story />
-        </Container>
-      </HalstackProvider>
+      <Container>
+        <Story />
+      </Container>
     ),
   ],
 };

--- a/packages/lib/src/HalstackContext.tsx
+++ b/packages/lib/src/HalstackContext.tsx
@@ -424,17 +424,10 @@ const HalstackProvider = ({ theme, advancedTheme, labels, children }: HalstackPr
   const parsedLabels = useMemo(() => (labels ? parseLabels(labels) : defaultTranslatedComponentLabels), [labels]);
 
   return (
-    <Halstack>
-      <HalstackContext.Provider value={parsedTheme}>
-        <HalstackLanguageContext.Provider value={parsedLabels}>{children}</HalstackLanguageContext.Provider>
-      </HalstackContext.Provider>
-    </Halstack>
+    <HalstackContext.Provider value={parsedTheme}>
+      <HalstackLanguageContext.Provider value={parsedLabels}>{children}</HalstackLanguageContext.Provider>
+    </HalstackContext.Provider>
   );
 };
 
-const Halstack = styled.div`
-  @import url("https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap&family=Material+Symbols+Outlined:FILL@0..1");
-`;
-
-export default HalstackContext;
-export { HalstackProvider, HalstackLanguageContext };
+export { HalstackContext as default, HalstackProvider, HalstackLanguageContext };

--- a/packages/lib/src/fonts.css
+++ b/packages/lib/src/fonts.css
@@ -1,0 +1,1 @@
+@import url("https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap&family=Material+Symbols+Outlined:FILL@0..1");

--- a/packages/lib/src/icon/Icon.tsx
+++ b/packages/lib/src/icon/Icon.tsx
@@ -1,18 +1,14 @@
 import styled from "styled-components";
 
-type IconPropsType = {
-  icon: string;
-};
-
-const DxcIcon = ({ icon }: IconPropsType): JSX.Element => {
-  let filled = false;
-  let iconName = icon;
-  if (icon.startsWith("filled_")) {
-    filled = true;
-    iconName = icon.replace(/filled_/g, "");
-  }
-  return <IconContainer role="img" aria-label={icon} filled={filled} icon={iconName} aria-hidden="true" />;
-};
+const DxcIcon = ({ icon }: { icon: string }): JSX.Element => (
+  <IconContainer
+    role="img"
+    aria-label={icon}
+    filled={icon.startsWith("filled_")}
+    icon={icon.startsWith("filled_") ? icon.replace(/filled_/g, "") : icon}
+    aria-hidden="true"
+  />
+);
 
 const IconContainer = styled.span<{
   icon: string;

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,111 +1,54 @@
-import DxcAccordion from "./accordion/Accordion";
-import DxcAccordionGroup from "./accordion-group/AccordionGroup";
-import DxcAlert from "./alert/Alert";
-import DxcApplicationLayout from "./layout/ApplicationLayout";
-import DxcBadge from "./badge/Badge";
-import DxcBleed from "./bleed/Bleed";
-import DxcBreadcrumbs from "./breadcrumbs/Breadcrumbs";
-import DxcBulletedList from "./bulleted-list/BulletedList";
-import DxcButton from "./button/Button";
-import DxcCard from "./card/Card";
-import DxcCheckbox from "./checkbox/Checkbox";
-import DxcChip from "./chip/Chip";
-import DxcContainer from "./container/Container";
-import DxcContextualMenu from "./contextual-menu/ContextualMenu";
-import DxcDataGrid from "./data-grid/DataGrid";
-import DxcDateInput from "./date-input/DateInput";
-import DxcDialog from "./dialog/Dialog";
-import DxcDivider from "./divider/Divider";
-import DxcDropdown from "./dropdown/Dropdown";
-import DxcFileInput from "./file-input/FileInput";
-import DxcFlex from "./flex/Flex";
-import DxcGrid from "./grid/Grid";
-import DxcHeading from "./heading/Heading";
-import DxcImage from "./image/Image";
-import DxcInset from "./inset/Inset";
-import DxcLink from "./link/Link";
-import DxcNavTabs from "./nav-tabs/NavTabs";
-import DxcNumberInput from "./number-input/NumberInput";
-import DxcPaginator from "./paginator/Paginator";
-import DxcParagraph from "./paragraph/Paragraph";
-import DxcPasswordInput from "./password-input/PasswordInput";
-import DxcProgressBar from "./progress-bar/ProgressBar";
-import DxcQuickNav from "./quick-nav/QuickNav";
-import DxcRadioGroup from "./radio-group/RadioGroup";
-import DxcResultsetTable from "./resultset-table/ResultsetTable";
-import DxcSelect from "./select/Select";
-import DxcSlider from "./slider/Slider";
-import DxcSpinner from "./spinner/Spinner";
-import DxcStatusLight from "./status-light/StatusLight";
-import DxcSwitch from "./switch/Switch";
-import DxcTable from "./table/Table";
-import DxcTabs from "./tabs/Tabs";
-import DxcTag from "./tag/Tag";
-import DxcTextarea from "./textarea/Textarea";
-import DxcTextInput from "./text-input/TextInput";
-import DxcToastsQueue from "./toast/ToastsQueue";
-import DxcToggleGroup from "./toggle-group/ToggleGroup";
-import DxcTooltip from "./tooltip/Tooltip";
-import DxcTypography from "./typography/Typography";
-import DxcWizard from "./wizard/Wizard";
+import "./fonts.css";
 
-import useToast from "./toast/useToast";
-
-import HalstackContext, { HalstackProvider, HalstackLanguageContext } from "./HalstackContext";
-
-export {
-  DxcAccordion,
-  DxcAccordionGroup,
-  DxcAlert,
-  DxcApplicationLayout,
-  DxcBadge,
-  DxcBleed,
-  DxcBreadcrumbs,
-  DxcBulletedList,
-  DxcButton,
-  DxcCard,
-  DxcCheckbox,
-  DxcChip,
-  DxcContainer,
-  DxcContextualMenu,
-  DxcDataGrid,
-  DxcDateInput,
-  DxcDialog,
-  DxcDivider,
-  DxcDropdown,
-  DxcFileInput,
-  DxcFlex,
-  DxcGrid,
-  DxcHeading,
-  DxcImage,
-  DxcInset,
-  DxcLink,
-  DxcNavTabs,
-  DxcNumberInput,
-  DxcPaginator,
-  DxcParagraph,
-  DxcPasswordInput,
-  DxcProgressBar,
-  DxcQuickNav,
-  DxcRadioGroup,
-  DxcResultsetTable,
-  DxcSelect,
-  DxcSlider,
-  DxcSpinner,
-  DxcStatusLight,
-  DxcSwitch,
-  DxcTable,
-  DxcTabs,
-  DxcTag,
-  DxcTextarea,
-  DxcTextInput,
-  DxcToastsQueue,
-  DxcToggleGroup,
-  DxcTooltip,
-  DxcTypography,
-  DxcWizard,
-  HalstackContext,
-  HalstackLanguageContext,
-  HalstackProvider,
-  useToast,
-};
+export { default as DxcAccordion } from "./accordion/Accordion";
+export { default as DxcAccordionGroup } from "./accordion-group/AccordionGroup";
+export { default as DxcAlert } from "./alert/Alert";
+export { default as DxcApplicationLayout } from "./layout/ApplicationLayout";
+export { default as DxcBadge } from "./badge/Badge";
+export { default as DxcBleed } from "./bleed/Bleed";
+export { default as DxcBreadcrumbs } from "./breadcrumbs/Breadcrumbs";
+export { default as DxcBulletedList } from "./bulleted-list/BulletedList";
+export { default as DxcButton } from "./button/Button";
+export { default as DxcCard } from "./card/Card";
+export { default as DxcCheckbox } from "./checkbox/Checkbox";
+export { default as DxcChip } from "./chip/Chip";
+export { default as DxcContainer } from "./container/Container";
+export { default as DxcContextualMenu } from "./contextual-menu/ContextualMenu";
+export { default as DxcDataGrid } from "./data-grid/DataGrid";
+export { default as DxcDateInput } from "./date-input/DateInput";
+export { default as DxcDialog } from "./dialog/Dialog";
+export { default as DxcDivider } from "./divider/Divider";
+export { default as DxcDropdown } from "./dropdown/Dropdown";
+export { default as DxcFileInput } from "./file-input/FileInput";
+export { default as DxcFlex } from "./flex/Flex";
+export { default as DxcGrid } from "./grid/Grid";
+export { default as DxcHeading } from "./heading/Heading";
+export { default as DxcImage } from "./image/Image";
+export { default as DxcInset } from "./inset/Inset";
+export { default as DxcLink } from "./link/Link";
+export { default as DxcNavTabs } from "./nav-tabs/NavTabs";
+export { default as DxcNumberInput } from "./number-input/NumberInput";
+export { default as DxcPaginator } from "./paginator/Paginator";
+export { default as DxcParagraph } from "./paragraph/Paragraph";
+export { default as DxcPasswordInput } from "./password-input/PasswordInput";
+export { default as DxcProgressBar } from "./progress-bar/ProgressBar";
+export { default as DxcQuickNav } from "./quick-nav/QuickNav";
+export { default as DxcRadioGroup } from "./radio-group/RadioGroup";
+export { default as DxcResultsetTable } from "./resultset-table/ResultsetTable";
+export { default as DxcSelect } from "./select/Select";
+export { default as DxcSlider } from "./slider/Slider";
+export { default as DxcSpinner } from "./spinner/Spinner";
+export { default as DxcStatusLight } from "./status-light/StatusLight";
+export { default as DxcSwitch } from "./switch/Switch";
+export { default as DxcTable } from "./table/Table";
+export { default as DxcTabs } from "./tabs/Tabs";
+export { default as DxcTag } from "./tag/Tag";
+export { default as DxcTextarea } from "./textarea/Textarea";
+export { default as DxcTextInput } from "./text-input/TextInput";
+export { default as DxcToastsQueue } from "./toast/ToastsQueue";
+export { default as DxcToggleGroup } from "./toggle-group/ToggleGroup";
+export { default as DxcTooltip } from "./tooltip/Tooltip";
+export { default as DxcTypography } from "./typography/Typography";
+export { default as DxcWizard } from "./wizard/Wizard";
+export { default as HalstackContext, HalstackProvider, HalstackLanguageContext } from "./HalstackContext";
+export { default as useToast } from "./toast/useToast";

--- a/packages/lib/src/select/Select.stories.tsx
+++ b/packages/lib/src/select/Select.stories.tsx
@@ -213,9 +213,9 @@ const options_material = [
 ];
 
 const optionsWithEllipsis = [
-  { label: "Optiond1234567890123456789012345678901234", value: "1" },
-  { label: "Optiond12345678901234567890123456789012345", value: "2" },
-  { label: "Option 031111111111111111111111111111222", value: "3" },
+  { label: "Optiond1234567890123456789012345678901234123123", value: "1" },
+  { label: "Optiond123456789012345678901234567890123451231231", value: "2" },
+  { label: "Option 03111111111111111111111111111122222222", value: "3" },
 ];
 
 const opinionatedTheme = {
@@ -647,7 +647,7 @@ const TooltipOption = () => {
   return (
     <ThemeProvider theme={colorsTheme.select}>
       <ExampleContainer expanded>
-        <Title title="List option has tooltip when it overflows" theme="light" level={4} />{" "}
+        <Title title="List option has tooltip when it overflows" theme="light" level={4} />
         <Listbox
           id="x8"
           currentValue="1"

--- a/packages/lib/src/select/Select.stories.tsx
+++ b/packages/lib/src/select/Select.stories.tsx
@@ -747,8 +747,8 @@ ValueWithEllipsisTooltip.play = async ({ canvasElement }) => {
 export const ListboxOptionWithEllipsisTooltip = TooltipOption.bind({});
 ListboxOptionWithEllipsisTooltip.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
-  await userEvent.hover(canvas.getByText("Optiond12345678901234567890123456789012345"));
-  await userEvent.hover(canvas.getByText("Optiond12345678901234567890123456789012345"));
+  await userEvent.hover(canvas.getByText("Optiond123456789012345678901234567890123451231231"));
+  await userEvent.hover(canvas.getByText("Optiond123456789012345678901234567890123451231231"));
 };
 
 export const ClearActionTooltip = TooltipClear.bind({});

--- a/packages/lib/tsup.config.ts
+++ b/packages/lib/tsup.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
+  clean: true,
+  dts: true,
   entry: ["src/index.ts"],
   format: ["cjs", "esm"],
-  dts: true,
+  injectStyle: true,
   minify: true,
   splitting: false,
-  clean: true,
 });


### PR DESCRIPTION
**Checklist**

- [x] The build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Description**
Using the `injectStyles` flag of tsup, we can add CSS styles to the Halstack build. I took advantage of that to import the Material Icons into our build, so that our components can have them by default, without needing to use `HalstackProvider`. This is an improvement on the current approach.
