### PR TITLE
Updates on the FocusLock and Dialog

### DIFF
--- a/apps/website/screens/components/dialog/code/DialogCodePage.tsx
+++ b/apps/website/screens/components/dialog/code/DialogCodePage.tsx
@@ -25,7 +25,7 @@ const sections = [
         </thead>
         <tbody>
           <tr>
-            <td>isCloseVisible</td>
+            <td>closable</td>
             <td>
               <TableCode>boolean</TableCode>
             </td>

--- a/apps/website/screens/components/dialog/code/examples/backgroundClick.ts
+++ b/apps/website/screens/components/dialog/code/examples/backgroundClick.ts
@@ -11,7 +11,7 @@ const code = `() => {
     <DxcInset space="2rem">
       <DxcButton label="Enter your data" onClick={handleClick} />
       {isDialogVisible && (
-        <DxcDialog onBackgroundClick={handleClick} isCloseVisible={false}>
+        <DxcDialog onBackgroundClick={handleClick} closable={false}>
           <DxcInset space="1.5rem">
             Please enter your personal information.
           </DxcInset>

--- a/apps/website/screens/theme-generator/ImportDialog.tsx
+++ b/apps/website/screens/theme-generator/ImportDialog.tsx
@@ -53,7 +53,7 @@ const ImportDialog = ({ customThemeSchema, setCustomTheme, setDialogVisible }: I
   };
 
   return (
-    <DxcDialog isCloseVisible={false} onBackgroundClick={closeDialog}>
+    <DxcDialog closable={false} onBackgroundClick={closeDialog}>
       <ImportDialogContainer>
         <DxcHeading text="Import theme" level={2} weight="normal" />
         <DxcTextarea

--- a/packages/lib/src/dialog/Dialog.accessibility.test.tsx
+++ b/packages/lib/src/dialog/Dialog.accessibility.test.tsx
@@ -11,7 +11,7 @@ describe("Dialog component accessibility tests", () => {
   });
   it("Should not have basic accessibility issues for close button not visible", async () => {
     // baseElement is needed when using React Portals
-    const { baseElement } = render(<DxcDialog isCloseVisible={false}>Dialog text</DxcDialog>);
+    const { baseElement } = render(<DxcDialog closable={false}>Dialog text</DxcDialog>);
     const results = await axe(baseElement);
     expect(results).toHaveNoViolations();
   });

--- a/packages/lib/src/dialog/Dialog.stories.tsx
+++ b/packages/lib/src/dialog/Dialog.stories.tsx
@@ -11,6 +11,8 @@ import DxcInset from "../inset/Inset";
 import DxcParagraph from "../paragraph/Paragraph";
 import DxcTextInput from "../text-input/TextInput";
 import DxcDialog from "./Dialog";
+import DxcDateInput from "../date-input/DateInput";
+import DxcSelect from "../select/Select";
 import DxcTooltip from "../tooltip/Tooltip";
 
 export default {
@@ -245,28 +247,20 @@ export const DialogWithInputs = () => (
   <ExampleContainer expanded={true}>
     <Title title="Dialog with inputs" theme="light" level={4} />
     <DxcDialog>
-      <DxcInset space="1.5rem">
-        <DxcFlex gap="2rem" direction="column">
-          <DxcHeading level={4} text="Example form" />
-          <DxcFlex gap="1rem" direction="column">
-            <DxcTextInput size="fillParent" label="Name" />
-            <DxcTooltip label="Input">
-              <DxcTextInput size="fillParent" label="Surname" />
-            </DxcTooltip>
-          </DxcFlex>
-          <DxcAlert
-            semantic="error"
-            title="Error"
-            message={{
-              text: "User: arn:aws:xxx::xxxxxxxxxxxx:assumed-role/assure-sandbox-xxxx-xxxxxxxxxxxxxxxxxxxxxxxxxx/sandbox-xxxx-xxxxxxxxxxxxxxxxxx is not authorized to perform: lambda:xxxxxxxxxxxxxx on resource: arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:sandbox-xxxx-xx-xxxxxxx-xxxxxxx-lambda because no identity-based policy allows the lambda:xxxxxxxxxxxxxx action",
-            }}
-          />
-          <DxcFlex justifyContent="flex-end" gap="0.5rem">
-            <DxcButton label="Cancel" mode="tertiary" />
-            <DxcButton label="Save" />
-          </DxcFlex>
-        </DxcFlex>
-      </DxcInset>
+      <DxcSelect label="Accept" options={[{ label: "Test", value: "test" }]} />
+      <DxcDateInput label="Older age" />
+      <DxcTooltip label="Text input tooltip label">
+        <DxcTextInput label="Name" />
+      </DxcTooltip>
+      <DxcAlert
+        semantic="error"
+        title="Error"
+        message={{
+          text: "User: arn:aws:xxx::xxxxxxxxxxxx:assumed-role/assure-sandbox-xxxx-xxxxxxxxxxxxxxxxxxxxxxxxxx/sandbox-xxxx-xxxxxxxxxxxxxxxxxx is not authorized to perform: lambda:xxxxxxxxxxxxxx on resource: arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:sandbox-xxxx-xx-xxxxxxx-xxxxxxx-lambda because no identity-based policy allows the lambda:xxxxxxxxxxxxxx action",
+        }}
+      />
+      <DxcButton label="Cancel" />
+      <DxcButton label="Save" />
     </DxcDialog>
   </ExampleContainer>
 );

--- a/packages/lib/src/dialog/Dialog.stories.tsx
+++ b/packages/lib/src/dialog/Dialog.stories.tsx
@@ -11,9 +11,6 @@ import DxcInset from "../inset/Inset";
 import DxcParagraph from "../paragraph/Paragraph";
 import DxcTextInput from "../text-input/TextInput";
 import DxcDialog from "./Dialog";
-import DxcDateInput from "../date-input/DateInput";
-import DxcSelect from "../select/Select";
-import DxcTooltip from "../tooltip/Tooltip";
 
 export default {
   title: "Dialog",
@@ -247,20 +244,26 @@ export const DialogWithInputs = () => (
   <ExampleContainer expanded={true}>
     <Title title="Dialog with inputs" theme="light" level={4} />
     <DxcDialog>
-      <DxcSelect label="Accept" options={[{ label: "Test", value: "test" }]} />
-      <DxcDateInput label="Older age" />
-      <DxcTooltip label="Text input tooltip label">
-        <DxcTextInput label="Name" />
-      </DxcTooltip>
-      <DxcAlert
-        semantic="error"
-        title="Error"
-        message={{
-          text: "User: arn:aws:xxx::xxxxxxxxxxxx:assumed-role/assure-sandbox-xxxx-xxxxxxxxxxxxxxxxxxxxxxxxxx/sandbox-xxxx-xxxxxxxxxxxxxxxxxx is not authorized to perform: lambda:xxxxxxxxxxxxxx on resource: arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:sandbox-xxxx-xx-xxxxxxx-xxxxxxx-lambda because no identity-based policy allows the lambda:xxxxxxxxxxxxxx action",
-        }}
-      />
-      <DxcButton label="Cancel" />
-      <DxcButton label="Save" />
+      <DxcInset space="1.5rem">
+        <DxcFlex gap="2rem" direction="column">
+          <DxcHeading level={4} text="Example form" />
+          <DxcFlex gap="1rem" direction="column">
+            <DxcTextInput size="fillParent" label="Name" />
+            <DxcTextInput size="fillParent" label="Surname" />
+          </DxcFlex>
+          <DxcAlert
+            semantic="error"
+            title="Error"
+            message={{
+              text: "User: arn:aws:xxx::xxxxxxxxxxxx:assumed-role/assure-sandbox-xxxx-xxxxxxxxxxxxxxxxxxxxxxxxxx/sandbox-xxxx-xxxxxxxxxxxxxxxxxx is not authorized to perform: lambda:xxxxxxxxxxxxxx on resource: arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:sandbox-xxxx-xx-xxxxxxx-xxxxxxx-lambda because no identity-based policy allows the lambda:xxxxxxxxxxxxxx action",
+            }}
+          />
+          <DxcFlex justifyContent="flex-end" gap="0.5rem">
+            <DxcButton label="Cancel" mode="tertiary" />
+            <DxcButton label="Save" />
+          </DxcFlex>
+        </DxcFlex>
+      </DxcInset>
     </DxcDialog>
   </ExampleContainer>
 );

--- a/packages/lib/src/dialog/Dialog.stories.tsx
+++ b/packages/lib/src/dialog/Dialog.stories.tsx
@@ -11,6 +11,7 @@ import DxcInset from "../inset/Inset";
 import DxcParagraph from "../paragraph/Paragraph";
 import DxcTextInput from "../text-input/TextInput";
 import DxcDialog from "./Dialog";
+import DxcTooltip from "../tooltip/Tooltip";
 
 export default {
   title: "Dialog",
@@ -249,14 +250,15 @@ export const DialogWithInputs = () => (
           <DxcHeading level={4} text="Example form" />
           <DxcFlex gap="1rem" direction="column">
             <DxcTextInput size="fillParent" label="Name" />
-            <DxcTextInput size="fillParent" label="Surname" />
+            <DxcTooltip label="Input">
+              <DxcTextInput size="fillParent" label="Surname" />
+            </DxcTooltip>
           </DxcFlex>
           <DxcAlert
             semantic="error"
             title="Error"
             message={{
-              text:
-                "User: arn:aws:xxx::xxxxxxxxxxxx:assumed-role/assure-sandbox-xxxx-xxxxxxxxxxxxxxxxxxxxxxxxxx/sandbox-xxxx-xxxxxxxxxxxxxxxxxx is not authorized to perform: lambda:xxxxxxxxxxxxxx on resource: arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:sandbox-xxxx-xx-xxxxxxx-xxxxxxx-lambda because no identity-based policy allows the lambda:xxxxxxxxxxxxxx action",
+              text: "User: arn:aws:xxx::xxxxxxxxxxxx:assumed-role/assure-sandbox-xxxx-xxxxxxxxxxxxxxxxxxxxxxxxxx/sandbox-xxxx-xxxxxxxxxxxxxxxxxx is not authorized to perform: lambda:xxxxxxxxxxxxxx on resource: arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:sandbox-xxxx-xx-xxxxxxx-xxxxxxx-lambda because no identity-based policy allows the lambda:xxxxxxxxxxxxxx action",
             }}
           />
           <DxcFlex justifyContent="flex-end" gap="0.5rem">
@@ -317,7 +319,7 @@ export const DialogWithoutOverlay = () => (
 export const DialogCloseVisibleFalse = () => (
   <ExampleContainer expanded={true}>
     <Title title="Dialog Close Visible" theme="dark" level={4} />
-    <DxcDialog isCloseVisible={false}>
+    <DxcDialog closable={false}>
       <DxcInset space="1.5rem">
         <DxcParagraph>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi egestas luctus porttitor. Donec massa magna,

--- a/packages/lib/src/dialog/Dialog.test.tsx
+++ b/packages/lib/src/dialog/Dialog.test.tsx
@@ -12,6 +12,7 @@ import DxcSwitch from "../switch/Switch";
 import DxcTextInput from "../text-input/TextInput";
 import DxcTextarea from "../textarea/Textarea";
 import DxcDialog from "./Dialog";
+import DxcTooltip from "../tooltip/Tooltip";
 
 (global as any).ResizeObserver = class ResizeObserver {
   observe() {}
@@ -35,13 +36,13 @@ describe("Dialog component tests", () => {
   });
 
   test("Dialog renders without close button", () => {
-    const { queryByRole } = render(<DxcDialog isCloseVisible={false}>dialog-text</DxcDialog>);
+    const { queryByRole } = render(<DxcDialog closable={false}>dialog-text</DxcDialog>);
     expect(queryByRole("button")).toBeFalsy();
   });
 
   test("Dialog renders with aria-modal false when overlay is not used", () => {
     const { getByRole } = render(
-      <DxcDialog isCloseVisible={false} overlay={false}>
+      <DxcDialog closable={false} overlay={false}>
         dialog-text
       </DxcDialog>
     );
@@ -215,13 +216,17 @@ describe("Dialog component: Focus lock tests", () => {
         <DxcCheckbox label="Older age" disabled />
         <DxcSelect label="Country" options={options} disabled />
         <DxcRadioGroup label="Country" options={options} disabled />
-        <DxcTextInput label="Name" disabled />
+        <DxcTooltip label="Text input tooltip label">
+          <DxcTextInput label="Name" disabled />
+        </DxcTooltip>
         <DxcButton label="Accept" tabIndex={-1} />
         <DxcCheckbox label="Older age" tabIndex={-1} />
         <DxcSelect label="Country" options={options} tabIndex={-1} />
         <DxcRadioGroup label="Country" options={options} tabIndex={-1} />
         <DxcTextInput label="Name" tabIndex={-1} />
-        <DxcTextarea label="Description" />
+        <DxcTooltip label="Text input tooltip label">
+          <DxcTextarea label="Description" />
+        </DxcTooltip>
       </DxcDialog>
     );
     const textarea = getAllByRole("textbox")[2];
@@ -264,7 +269,7 @@ describe("Dialog component: Focus lock tests", () => {
     const { getAllByRole } = render(
       <>
         <DxcTextInput label="Name" />
-        <DxcDialog isCloseVisible={false}>
+        <DxcDialog closable={false}>
           <h2>Policy agreement</h2>
           <p>Sample text.</p>
         </DxcDialog>

--- a/packages/lib/src/dialog/Dialog.tsx
+++ b/packages/lib/src/dialog/Dialog.tsx
@@ -8,66 +8,6 @@ import useTranslatedLabels from "../useTranslatedLabels";
 import FocusLock from "../utils/FocusLock";
 import DialogPropsType from "./types";
 
-const DxcDialog = ({
-  isCloseVisible = true,
-  onCloseClick,
-  children,
-  overlay = true,
-  onBackgroundClick,
-  tabIndex = 0,
-}: DialogPropsType): JSX.Element => {
-  const colorsTheme = useTheme();
-  const translatedLabels = useTranslatedLabels();
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onCloseClick?.();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [onCloseClick]);
-
-  return (
-    <ThemeProvider theme={colorsTheme.dialog}>
-      <BodyStyle />
-      {createPortal(
-        <DialogContainer>
-          {overlay && (
-            <Overlay
-              onClick={() => {
-                onBackgroundClick?.();
-              }}
-            />
-          )}
-          <Dialog role="dialog" aria-modal={overlay} isCloseVisible={isCloseVisible} aria-label="Dialog">
-            <FocusLock>
-              {children}
-              {isCloseVisible && (
-                <CloseIconAction
-                  onClick={() => {
-                    onCloseClick?.();
-                  }}
-                  aria-label={translatedLabels.dialog.closeIconAriaLabel}
-                  tabIndex={tabIndex}
-                >
-                  <DxcIcon icon="close" />
-                </CloseIconAction>
-              )}
-            </FocusLock>
-          </Dialog>
-        </DialogContainer>,
-        document.body
-      )}
-    </ThemeProvider>
-  );
-};
-
 const BodyStyle = createGlobalStyle`
   body {
     overflow: hidden;
@@ -91,14 +31,14 @@ const Overlay = styled.div`
   background-color: ${(props) => props.theme.overlayColor};
 `;
 
-const Dialog = styled.div<{ isCloseVisible: DialogPropsType["isCloseVisible"] }>`
+const Dialog = styled.div<{ closable: DialogPropsType["closable"] }>`
   position: relative;
   box-sizing: border-box;
   max-width: 80%;
   min-width: 696px;
   border-radius: 4px;
   background-color: ${(props) => props.theme.backgroundColor};
-  ${(props) => props.isCloseVisible && "min-height: 72px;"}
+  ${(props) => props.closable && "min-height: 72px;"}
   box-shadow: ${(props) =>
     `${props.theme.boxShadowOffsetX} ${props.theme.boxShadowOffsetY} ${props.theme.boxShadowBlur} ${props.theme.boxShadowColor}`};
   z-index: 2147483647;
@@ -141,5 +81,65 @@ const CloseIconAction = styled.button`
     font-size: ${(props) => props.theme.closeIconSize};
   }
 `;
+
+const DxcDialog = ({
+  closable = true,
+  onCloseClick,
+  children,
+  overlay = true,
+  onBackgroundClick,
+  tabIndex = 0,
+}: DialogPropsType): JSX.Element => {
+  const colorsTheme = useTheme();
+  const translatedLabels = useTranslatedLabels();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCloseClick?.();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onCloseClick]);
+
+  return (
+    <ThemeProvider theme={colorsTheme.dialog}>
+      <BodyStyle />
+      {createPortal(
+        <DialogContainer>
+          {overlay && (
+            <Overlay
+              onClick={() => {
+                onBackgroundClick?.();
+              }}
+            />
+          )}
+          <Dialog role="dialog" aria-modal={overlay} closable={closable} aria-label="Dialog">
+            <FocusLock>
+              {children}
+              {closable && (
+                <CloseIconAction
+                  onClick={() => {
+                    onCloseClick?.();
+                  }}
+                  aria-label={translatedLabels.dialog.closeIconAriaLabel}
+                  tabIndex={tabIndex}
+                >
+                  <DxcIcon icon="close" />
+                </CloseIconAction>
+              )}
+            </FocusLock>
+          </Dialog>
+        </DialogContainer>,
+        document.body
+      )}
+    </ThemeProvider>
+  );
+};
 
 export default DxcDialog;

--- a/packages/lib/src/dialog/types.ts
+++ b/packages/lib/src/dialog/types.ts
@@ -2,7 +2,7 @@ type Props = {
   /**
    * If true, the close button will be visible.
    */
-  isCloseVisible?: boolean;
+  closable?: boolean;
   /**
    * This function will be called when the user clicks the close button.
    * The responsibility of hiding the dialog lies with the user.

--- a/packages/lib/src/utils/FocusLock.tsx
+++ b/packages/lib/src/utils/FocusLock.tsx
@@ -69,7 +69,7 @@ const useFocusableElements = (ref: React.MutableRefObject<HTMLDivElement>): HTML
       const observer = new MutationObserver(() => {
         setFocusableElements(getFocusableElements(ref.current));
       });
-      observer.observe(ref.current, { childList: true, subtree: true, attributes: true });
+      observer.observe(ref.current, { childList: true, subtree: true });
       return () => {
         observer.disconnect();
       };
@@ -90,6 +90,7 @@ const useFocusableElements = (ref: React.MutableRefObject<HTMLDivElement>): HTML
 const FocusLock = ({ children }: { children: React.ReactNode }): JSX.Element => {
   const childrenContainerRef = useRef<HTMLDivElement>();
   const focusableElements = useFocusableElements(childrenContainerRef);
+  const initialFocus = useRef(false);
 
   const focusFirst = useCallback(() => {
     if (focusableElements?.length === 0) childrenContainerRef.current?.focus();
@@ -101,13 +102,15 @@ const FocusLock = ({ children }: { children: React.ReactNode }): JSX.Element => 
   };
 
   const focusLock = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Tab") focusableElements.length === 0 && event.preventDefault();
+    if (event.key === "Tab" && focusableElements.length === 0) event.preventDefault();
   };
 
   useEffect(() => {
-    if (!childrenContainerRef.current?.contains(document.activeElement) && !radixPortalContains(document.activeElement))
+    if (focusableElements !== undefined && !initialFocus.current) {
+      initialFocus.current = true;
       focusFirst();
-  }, [focusFirst]);
+    }
+  }, [focusableElements, focusFirst]);
 
   return (
     <>

--- a/packages/lib/src/utils/FocusLock.tsx
+++ b/packages/lib/src/utils/FocusLock.tsx
@@ -45,7 +45,7 @@ const attemptFocus = (element: HTMLElement): boolean => {
  * @param element: HTMLElement
  * @returns boolean: true if element is contained inside a Radix Portal, false otherwise.
  */
-const radixPortalContains = (activeElement: Element): boolean => {
+const radixPortalContains = (activeElement: Node): boolean => {
   const radixPortals = document.querySelectorAll("[data-radix-portal]");
   const radixPoppers = document.querySelectorAll("[data-radix-popper-content-wrapper]");
   return (
@@ -98,7 +98,7 @@ const FocusLock = ({ children }: { children: React.ReactNode }): JSX.Element => 
   }, [focusableElements]);
 
   const focusLast = () => {
-    focusableElements?.reverse()?.some((element) => attemptFocus(element));
+    focusableElements?.slice().reverse()?.some((element) => attemptFocus(element));
   };
 
   const focusLock = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -111,6 +111,23 @@ const FocusLock = ({ children }: { children: React.ReactNode }): JSX.Element => 
       focusFirst();
     }
   }, [focusableElements, focusFirst]);
+
+  useEffect(() => {
+    const focusGuardHandler = (event: FocusEvent) => {
+      if (
+        !childrenContainerRef.current?.contains(event.relatedTarget as Node) &&
+        !childrenContainerRef.current?.nextElementSibling?.contains(event.relatedTarget as Node) &&
+        !childrenContainerRef.current?.previousElementSibling?.contains(event.relatedTarget as Node) &&
+        !radixPortalContains(event.relatedTarget as Node)
+      )
+        focusFirst();
+    };
+
+    document.addEventListener("focusout", focusGuardHandler);
+    return () => {
+      document.removeEventListener("focusout", focusGuardHandler);
+    };
+  }, [focusFirst]);
 
   return (
     <>

--- a/packages/lib/src/utils/FocusLock.tsx
+++ b/packages/lib/src/utils/FocusLock.tsx
@@ -98,7 +98,10 @@ const FocusLock = ({ children }: { children: React.ReactNode }): JSX.Element => 
   }, [focusableElements]);
 
   const focusLast = () => {
-    focusableElements?.slice().reverse()?.some((element) => attemptFocus(element));
+    focusableElements
+      ?.slice()
+      .reverse()
+      ?.some((element) => attemptFocus(element));
   };
 
   const focusLock = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -114,11 +117,17 @@ const FocusLock = ({ children }: { children: React.ReactNode }): JSX.Element => 
 
   useEffect(() => {
     const focusGuardHandler = (event: FocusEvent) => {
+      const target = event.relatedTarget as Node | null;
+      const container = childrenContainerRef.current;
+
       if (
-        !childrenContainerRef.current?.contains(event.relatedTarget as Node) &&
-        !childrenContainerRef.current?.nextElementSibling?.contains(event.relatedTarget as Node) &&
-        !childrenContainerRef.current?.previousElementSibling?.contains(event.relatedTarget as Node) &&
-        !radixPortalContains(event.relatedTarget as Node)
+        target &&
+        !(
+          container?.contains(target) ||
+          container?.nextElementSibling?.contains(target) ||
+          container?.previousElementSibling?.contains(target) ||
+          radixPortalContains(target)
+        )
       )
         focusFirst();
     };


### PR DESCRIPTION
**Checklist**

- [x] The build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
The focus was not following the tabbing sequence in Dialog and Alert components when there was a component with the new Tooltip. It was an issue with the Focus Lock internal component.

**Description**
Summary of changes:
- Fixed the issue. The `MutationObserver` from the `FocusLock` component was executing itself each time the focus changed, due to a flag of the observer (`{ attributes: true }`). Now it is only executing when the tree inside the component changes, which is the expected behavior.
  - Fixed some usual issues with the Focus Lock like the Date Input calendar focus return on close, added focus guards etc.
  - New tests.
- Change Dialog's prop `isCloseVisible` to `closable`, to match the new Alert approach for this same property.
