### PR TITLE
ariaLabel prop added to the radioGroup

### DIFF
--- a/apps/website/screens/components/radio-group/code/RadioGroupCodePage.tsx
+++ b/apps/website/screens/components/radio-group/code/RadioGroupCodePage.tsx
@@ -206,6 +206,14 @@ const sections = [
             <td>Reference to the component.</td>
             <td>-</td>
           </tr>
+          <tr>
+            <td>ariaLabel</td>
+            <td>
+              <TableCode>string</TableCode>
+            </td>
+            <td>Specifies a string to be used as the name for the radio group when no `label` is provided.</td>
+            <td>'Radio group'</td>
+          </tr>
         </tbody>
       </DxcTable>
     ),

--- a/packages/lib/src/radio-group/RadioGroup.test.tsx
+++ b/packages/lib/src/radio-group/RadioGroup.test.tsx
@@ -32,6 +32,7 @@ describe("Radio Group component tests", () => {
     expect(radioGroup.getAttribute("aria-invalid")).toBe("false");
     expect(radioGroup.getAttribute("aria-required")).toBe("true");
     expect(radioGroup.getAttribute("aria-orientation")).toBe("vertical");
+    expect(radioGroup.getAttribute("aria-label")).toBeNull();
     expect(error.getAttribute("aria-live")).toBe("off");
     radios.forEach((radio, index) => {
       // if no option was previously selected, first option is the focusable one
@@ -39,8 +40,13 @@ describe("Radio Group component tests", () => {
       else expect(radio.tabIndex).toBe(-1);
       expect(radio.getAttribute("aria-checked")).toBe("false");
       expect(radio.getAttribute("aria-disabled")).toBe("false");
-      expect(radio.getAttribute("aria-labelledby")).toBe(getByText(`Option 0${index + 1}`).id);
     });
+  });
+
+  test("Initial render has correct aria-label", () => {
+    const { getByRole } = render(<DxcRadioGroup ariaLabel="Example aria label" options={options} error="" />);
+    const radioGroup = getByRole("radiogroup");
+    expect(radioGroup.getAttribute("aria-label")).toBe("Example aria label");
   });
 
   test("aria-orientation attribute changes depending on stacking prop value", () => {

--- a/packages/lib/src/radio-group/RadioGroup.tsx
+++ b/packages/lib/src/radio-group/RadioGroup.tsx
@@ -27,6 +27,7 @@ const DxcRadioGroup = forwardRef<RefType, RadioGroupPropsType>(
       onBlur,
       error,
       tabIndex = 0,
+      ariaLabel = "Radio group",
     },
     ref
   ): JSX.Element => {
@@ -160,12 +161,13 @@ const DxcRadioGroup = forwardRef<RefType, RadioGroupPropsType>(
             stacking={stacking}
             role="radiogroup"
             aria-disabled={disabled}
-            aria-labelledby={radioGroupLabelId}
+            aria-labelledby={label ? radioGroupLabelId : undefined}
             aria-invalid={!!error}
             aria-errormessage={error ? errorId : undefined}
             aria-required={!disabled && !readOnly && !optional}
             aria-readonly={readOnly}
             aria-orientation={stacking === "column" ? "vertical" : "horizontal"}
+            aria-label={label ? undefined : ariaLabel}
           >
             <ValueInput name={name} disabled={disabled} value={value ?? innerValue ?? ""} readOnly />
             {innerOptions.map((option, index) => (

--- a/packages/lib/src/radio-group/types.ts
+++ b/packages/lib/src/radio-group/types.ts
@@ -91,6 +91,10 @@ type RadioGroupProps = {
    * Value of the tabindex attribute.
    */
   tabIndex?: number;
+  /**
+   * Specifies a string to be used as the name for the radio group when no `label` is provided.
+   */
+  ariaLabel?: string;
 };
 
 /**


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
`ariaLabel` prop added to the radioGroup component.
