### PR TITLE
Prevent displaying `Paginator` when `itemsPerPage` > `totalItems` 

### DIFF
--- a/packages/lib/src/paginator/Paginator.test.tsx
+++ b/packages/lib/src/paginator/Paginator.test.tsx
@@ -22,13 +22,13 @@ import DxcPaginator from "./Paginator";
 describe("Paginator component tests", () => {
   test("Paginator renders with default values", () => {
     const { getByText } = render(<DxcPaginator />);
-    expect(getByText("1 to 1 of 1")).toBeTruthy();
-    expect(getByText("Page: 1 of 1")).toBeTruthy();
+    expect(getByText("1 to 5 of 10")).toBeTruthy();
+    expect(getByText("Page: 1 of 2")).toBeTruthy();
   });
 
   test("Paginator renders with currentPage", () => {
-    const { getByText } = render(<DxcPaginator currentPage={2} />);
-    expect(getByText("Page: 2 of 1")).toBeTruthy();
+    const { getByText } = render(<DxcPaginator itemsPerPage={2} totalItems={4} currentPage={2} />);
+    expect(getByText("Page: 2 of 2")).toBeTruthy();
   });
 
   test("Paginator renders with itemsPerPageOptions", () => {

--- a/packages/lib/src/paginator/Paginator.tsx
+++ b/packages/lib/src/paginator/Paginator.tsx
@@ -10,7 +10,7 @@ const DxcPaginator = ({
   currentPage = 1,
   itemsPerPage = 5,
   itemsPerPageOptions,
-  totalItems = 1,
+  totalItems = 10,
   showGoToPage,
   onPageChange,
   itemsPerPageFunction,
@@ -28,7 +28,7 @@ const DxcPaginator = ({
   const colorsTheme = useContext(HalstackContext);
   const translatedLabels = useContext(HalstackLanguageContext);
 
-  return (
+  return totalItems > itemsPerPage ? (
     <ThemeProvider theme={colorsTheme.paginator}>
       <DxcPaginatorContainer>
         <LabelsContainer>
@@ -126,6 +126,8 @@ const DxcPaginator = ({
         </LabelsContainer>
       </DxcPaginatorContainer>
     </ThemeProvider>
+  ) : (
+    <></>
   );
 };
 


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [ ] Build process is done without errors. All tests pass in the `/lib` directory.
- [ ] Self-reviewed the code before submitting.
- [ ] Meets accessibility standards.
- [ ] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Additional context**
It doesn't make sense to display the paginator when there is only one page, so I we are covering one additional scenario to not be displayed when not needed. Also updated tests and default values for the default state to make sense.
