### PR TITLE
`tabId` prop is no longer required

### DIFF
--- a/packages/lib/src/tabs/Tab.tsx
+++ b/packages/lib/src/tabs/Tab.tsx
@@ -155,6 +155,7 @@ const DxcTab = forwardRef(
           role="tab"
           tabIndex={activeTabId === label && !disabled ? tabIndex : -1}
           type="button"
+          aria-label={label ?? tabId ?? "tab"}
         >
           <LabelIconContainer iconPosition={iconPosition}>
             {icon && <IconContainer>{typeof icon === "string" ? <DxcIcon icon={icon} /> : icon}</IconContainer>}

--- a/packages/lib/src/tabs/Tab.tsx
+++ b/packages/lib/src/tabs/Tab.tsx
@@ -94,7 +94,7 @@ const Underline = styled.span<{ active: boolean }>`
 
 const DxcTab = forwardRef(
   (
-    { active, disabled, icon, label, notificationNumber, onClick, onHover, title, tabId }: TabProps,
+    { active, disabled, icon, label, notificationNumber, onClick, onHover, title, tabId = label }: TabProps,
     ref: Ref<HTMLButtonElement>
   ) => {
     const {
@@ -124,7 +124,7 @@ const DxcTab = forwardRef(
     }, [focusedTabId, tabId]);
 
     useEffect(() => {
-      if (active) setActiveTabId?.(tabId);
+      if (active) setActiveTabId?.(tabId ?? "");
     }, [active, tabId, setActiveTabId]);
 
     return (
@@ -135,7 +135,9 @@ const DxcTab = forwardRef(
           hasLabelAndIcon={Boolean(icon && label)}
           iconPosition={iconPosition}
           onClick={() => {
-            if (!isControlled) setActiveTabId?.(tabId);
+            if (!isControlled) {
+              setActiveTabId?.(tabId ?? "");
+            }
             onClick?.();
           }}
           onKeyDown={handleOnKeyDown}
@@ -156,7 +158,7 @@ const DxcTab = forwardRef(
         >
           <LabelIconContainer iconPosition={iconPosition}>
             {icon && <IconContainer>{typeof icon === "string" ? <DxcIcon icon={icon} /> : icon}</IconContainer>}
-            <Label>{label}</Label>
+            {label && <Label>{label}</Label>}
           </LabelIconContainer>
           {!disabled && notificationNumber && (
             <BadgeContainer hasLabelAndIcon={Boolean(icon && label)} iconPosition={iconPosition}>

--- a/packages/lib/src/tabs/Tabs.stories.tsx
+++ b/packages/lib/src/tabs/Tabs.stories.tsx
@@ -24,25 +24,25 @@ const iconSVG = (
 
 const tabs = (margin?: Space | Margin) => (
   <DxcTabs margin={margin}>
-    <DxcTabs.Tab label="Tab 1" tabId="Tab 1" title="test tooltip">
+    <DxcTabs.Tab label="Tab 1" title="test tooltip">
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 2" label="Tab 2">
+    <DxcTabs.Tab label="Tab 2">
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 3" label="Tab 3" disabled>
+    <DxcTabs.Tab label="Tab 3" disabled>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 4" label="Tab 4">
+    <DxcTabs.Tab label="Tab 4">
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 5" label="Tab 5">
+    <DxcTabs.Tab label="Tab 5">
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 6" label="Tab 6">
+    <DxcTabs.Tab label="Tab 6">
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 7" label="Tab 7">
+    <DxcTabs.Tab label="Tab 7">
       <></>
     </DxcTabs.Tab>
   </DxcTabs>
@@ -50,13 +50,13 @@ const tabs = (margin?: Space | Margin) => (
 
 const disabledTabs = (
   <DxcTabs>
-    <DxcTabs.Tab tabId="Tab 1" label="Tab 1" disabled>
+    <DxcTabs.Tab label="Tab 1" disabled>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 2" label="Tab 2" disabled>
+    <DxcTabs.Tab label="Tab 2" disabled>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 3" label="Tab 3" disabled>
+    <DxcTabs.Tab label="Tab 3" disabled>
       <></>
     </DxcTabs.Tab>
   </DxcTabs>
@@ -64,13 +64,13 @@ const disabledTabs = (
 
 const firstDisabledTabs = (
   <DxcTabs>
-    <DxcTabs.Tab tabId="Tab 1" label="Tab 1" disabled>
+    <DxcTabs.Tab label="Tab 1" disabled>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 2" label="Tab 2" disabled>
+    <DxcTabs.Tab label="Tab 2" disabled>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 3" label="Tab 3">
+    <DxcTabs.Tab label="Tab 3">
       <></>
     </DxcTabs.Tab>
   </DxcTabs>
@@ -78,25 +78,25 @@ const firstDisabledTabs = (
 
 const tabsNotification = (iconPosition?: "top" | "left") => (
   <DxcTabs iconPosition={iconPosition}>
-    <DxcTabs.Tab tabId="Tab 1" label="Tab 1" notificationNumber={true}>
+    <DxcTabs.Tab label="Tab 1" notificationNumber={true}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 2" label="Tab 2" notificationNumber={5}>
+    <DxcTabs.Tab label="Tab 2" notificationNumber={5}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 3" label="Tab 3" notificationNumber={100} disabled>
+    <DxcTabs.Tab label="Tab 3" notificationNumber={100} disabled>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 4" label="Tab 4" notificationNumber={200}>
+    <DxcTabs.Tab label="Tab 4" notificationNumber={200}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 5" label="Tab 5">
+    <DxcTabs.Tab label="Tab 5">
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 6" label="Tab 6">
+    <DxcTabs.Tab label="Tab 6">
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 7" label="Tab 7">
+    <DxcTabs.Tab label="Tab 7">
       <></>
     </DxcTabs.Tab>
   </DxcTabs>
@@ -104,25 +104,25 @@ const tabsNotification = (iconPosition?: "top" | "left") => (
 
 const tabsIcon = (iconPosition?: "top" | "left") => (
   <DxcTabs iconPosition={iconPosition}>
-    <DxcTabs.Tab tabId="Tab 1" label="Tab 1" icon={iconSVG}>
+    <DxcTabs.Tab tabId="Tab 1" icon={iconSVG}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 2" label="Tab 2" icon={iconSVG}>
+    <DxcTabs.Tab tabId="Tab 2" icon={iconSVG}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 3" label="Tab 3" icon={iconSVG} disabled>
+    <DxcTabs.Tab tabId="Tab 3" icon={iconSVG} disabled>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 4" label="Tab 4">
+    <DxcTabs.Tab tabId="Tab 4" icon="filled_star">
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 5" label="Tab 5" icon="mail">
+    <DxcTabs.Tab tabId="Tab 5" icon="mail">
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 6" label="Tab 6" icon="mail">
+    <DxcTabs.Tab tabId="Tab 6" icon="mail">
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 7" label="Tab 7" icon="mail">
+    <DxcTabs.Tab tabId="Tab 7" icon="mail">
       <></>
     </DxcTabs.Tab>
   </DxcTabs>
@@ -130,25 +130,25 @@ const tabsIcon = (iconPosition?: "top" | "left") => (
 
 const tabsNotificationIcon = (iconPosition?: "top" | "left") => (
   <DxcTabs iconPosition={iconPosition}>
-    <DxcTabs.Tab tabId="Tab 1" label="Tab 1" icon={iconSVG} notificationNumber={true}>
+    <DxcTabs.Tab label="Tab 1" icon={iconSVG} notificationNumber={true}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 2" label="Tab 2" icon={iconSVG} notificationNumber={5}>
+    <DxcTabs.Tab label="Tab 2" icon={iconSVG} notificationNumber={5}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 3" label="Tab 3" icon={iconSVG} notificationNumber={100} disabled>
+    <DxcTabs.Tab label="Tab 3" icon={iconSVG} notificationNumber={100} disabled>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 4" label="Tab 4" icon={iconSVG} notificationNumber={200}>
+    <DxcTabs.Tab label="Tab 4" icon={iconSVG} notificationNumber={200}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 5" label="Tab 5" icon={iconSVG}>
+    <DxcTabs.Tab label="Tab 5" icon={iconSVG}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 6" label="Tab 6" icon={iconSVG}>
+    <DxcTabs.Tab label="Tab 6" icon={iconSVG}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab 7" label="Tab 7" icon={iconSVG}>
+    <DxcTabs.Tab label="Tab 7" icon={iconSVG}>
       <></>
     </DxcTabs.Tab>
   </DxcTabs>

--- a/packages/lib/src/tabs/Tabs.stories.tsx
+++ b/packages/lib/src/tabs/Tabs.stories.tsx
@@ -128,6 +128,32 @@ const tabsIcon = (iconPosition?: "top" | "left") => (
   </DxcTabs>
 );
 
+const tabsIconLabel = (iconPosition?: "top" | "left") => (
+  <DxcTabs iconPosition={iconPosition}>
+    <DxcTabs.Tab label="Tab 1" icon={iconSVG}>
+      <></>
+    </DxcTabs.Tab>
+    <DxcTabs.Tab label="Tab 2" icon={iconSVG}>
+      <></>
+    </DxcTabs.Tab>
+    <DxcTabs.Tab label="Tab 3" icon={iconSVG} disabled>
+      <></>
+    </DxcTabs.Tab>
+    <DxcTabs.Tab label="Tab 4" icon="filled_star">
+      <></>
+    </DxcTabs.Tab>
+    <DxcTabs.Tab label="Tab 5" icon="mail">
+      <></>
+    </DxcTabs.Tab>
+    <DxcTabs.Tab label="Tab 6" icon="mail">
+      <></>
+    </DxcTabs.Tab>
+    <DxcTabs.Tab label="Tab 7" icon="mail">
+      <></>
+    </DxcTabs.Tab>
+  </DxcTabs>
+);
+
 const tabsNotificationIcon = (iconPosition?: "top" | "left") => (
   <DxcTabs iconPosition={iconPosition}>
     <DxcTabs.Tab label="Tab 1" icon={iconSVG} notificationNumber={true}>
@@ -187,10 +213,12 @@ const Tabs = () => (
     <ExampleContainer>
       <Title title="With icon position left" theme="light" level={4} />
       {tabsIcon()}
+      {tabsIconLabel()}
     </ExampleContainer>
     <ExampleContainer>
       <Title title="With icon position top" theme="light" level={4} />
       {tabsIcon("top")}
+      {tabsIconLabel("top")}
     </ExampleContainer>
     <ExampleContainer>
       <Title title="With icon and notification number" theme="light" level={4} />

--- a/packages/lib/src/tabs/Tabs.test.tsx
+++ b/packages/lib/src/tabs/Tabs.test.tsx
@@ -10,26 +10,26 @@ import DxcTabs from "./Tabs";
 
 const sampleTabs = (
   <DxcTabs>
-    <DxcTabs.Tab tabId="Tab-1" label="Tab-1" notificationNumber={10} defaultActive>
+    <DxcTabs.Tab label="Tab-1" notificationNumber={10} defaultActive>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-2" label="Tab-2" notificationNumber={20}>
+    <DxcTabs.Tab label="Tab-2" notificationNumber={20}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-3" label="Tab-3" notificationNumber={30}>
+    <DxcTabs.Tab label="Tab-3" notificationNumber={30}>
       <></>
     </DxcTabs.Tab>
   </DxcTabs>
 );
 const sampleTabsWithBadge = (
   <DxcTabs>
-    <DxcTabs.Tab tabId="Tab-1" label="Tab-1" notificationNumber={10}>
+    <DxcTabs.Tab label="Tab-1" notificationNumber={10}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-2" label="Tab-2" notificationNumber={20}>
+    <DxcTabs.Tab label="Tab-2" notificationNumber={20}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-3" label="Tab-3" notificationNumber={101} defaultActive>
+    <DxcTabs.Tab label="Tab-3" notificationNumber={101} defaultActive>
       <></>
     </DxcTabs.Tab>
   </DxcTabs>
@@ -37,36 +37,36 @@ const sampleTabsWithBadge = (
 
 const sampleTabsFirstDisabled = (
   <DxcTabs>
-    <DxcTabs.Tab tabId="Tab-1" label="Tab-1" disabled>
+    <DxcTabs.Tab label="Tab-1" disabled>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-2" label="Tab-2">
+    <DxcTabs.Tab label="Tab-2">
       <></>
     </DxcTabs.Tab>
   </DxcTabs>
 );
 const sampleTabsInteraction = (onTabClick: (() => void)[]) => (
   <DxcTabs>
-    <DxcTabs.Tab tabId="Tab-1" label="Tab-1" onClick={onTabClick[0]} defaultActive>
+    <DxcTabs.Tab label="Tab-1" onClick={onTabClick[0]} defaultActive>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-2" label="Tab-2" onClick={onTabClick[1]}>
+    <DxcTabs.Tab label="Tab-2" onClick={onTabClick[1]}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-3" label="Tab-3" onClick={onTabClick[2]}>
+    <DxcTabs.Tab label="Tab-3" onClick={onTabClick[2]}>
       <></>
     </DxcTabs.Tab>
   </DxcTabs>
 );
 const sampleTabsMiddleDisabled = (onTabClick: (() => void)[]) => (
   <DxcTabs>
-    <DxcTabs.Tab tabId="Tab-1" label="Tab-1" onClick={onTabClick[0]}>
+    <DxcTabs.Tab label="Tab-1" onClick={onTabClick[0]}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-2" label="Tab-2" onClick={onTabClick[1]} disabled>
+    <DxcTabs.Tab label="Tab-2" onClick={onTabClick[1]} disabled>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-3" label="Tab-3" onClick={onTabClick[2]}>
+    <DxcTabs.Tab label="Tab-3" onClick={onTabClick[2]}>
       <></>
     </DxcTabs.Tab>
   </DxcTabs>
@@ -74,13 +74,13 @@ const sampleTabsMiddleDisabled = (onTabClick: (() => void)[]) => (
 
 const sampleTabsLastTabNonDisabledFirstActive = (onTabClick: (() => void)[]) => (
   <DxcTabs>
-    <DxcTabs.Tab tabId="Tab-1" label="Tab-1" onClick={onTabClick[0]} disabled defaultActive>
+    <DxcTabs.Tab label="Tab-1" onClick={onTabClick[0]} disabled defaultActive>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-2" label="Tab-2" onClick={onTabClick[1]} disabled>
+    <DxcTabs.Tab label="Tab-2" onClick={onTabClick[1]} disabled>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-3" label="Tab-3" onClick={onTabClick[2]}>
+    <DxcTabs.Tab label="Tab-3" onClick={onTabClick[2]}>
       <></>
     </DxcTabs.Tab>
   </DxcTabs>
@@ -88,13 +88,27 @@ const sampleTabsLastTabNonDisabledFirstActive = (onTabClick: (() => void)[]) => 
 
 const sampleControlledTabsInteraction = (onTabClick: (() => void)[]) => (
   <DxcTabs>
-    <DxcTabs.Tab tabId="Tab-1" label="Tab-1" onClick={onTabClick[0]} active>
+    <DxcTabs.Tab label="Tab-1" onClick={onTabClick[0]} active>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-2" label="Tab-2" onClick={onTabClick[1]}>
+    <DxcTabs.Tab label="Tab-2" onClick={onTabClick[1]}>
       <></>
     </DxcTabs.Tab>
-    <DxcTabs.Tab tabId="Tab-3" label="Tab-3" onClick={onTabClick[2]}>
+    <DxcTabs.Tab label="Tab-3" onClick={onTabClick[2]}>
+      <></>
+    </DxcTabs.Tab>
+  </DxcTabs>
+);
+
+const sampleTabsWithoutLabel = (onTabClick: (() => void)[]) => (
+  <DxcTabs>
+    <DxcTabs.Tab tabId="Tab 1" icon="api" onClick={onTabClick[0]}>
+      <></>
+    </DxcTabs.Tab>
+    <DxcTabs.Tab tabId="Tab 2" icon="api" onClick={onTabClick[1]}>
+      <></>
+    </DxcTabs.Tab>
+    <DxcTabs.Tab tabId="Tab 3" icon="api" onClick={onTabClick[2]}>
       <></>
     </DxcTabs.Tab>
   </DxcTabs>
@@ -243,6 +257,7 @@ describe("Tabs component tests", () => {
     expect(tabs[2]?.getAttribute("aria-selected")).toBe("true");
     expect(onTabClick[2]).toHaveBeenCalled();
   });
+
   test("Controlled tabs interaction", () => {
     const onTabClick = [jest.fn(), jest.fn(), jest.fn()];
     const { getAllByRole } = render(sampleControlledTabsInteraction(onTabClick));
@@ -262,5 +277,26 @@ describe("Tabs component tests", () => {
     expect(tabs[0]?.getAttribute("aria-selected")).toBe("true");
     expect(tabs[1]?.getAttribute("aria-selected")).toBe("false");
     expect(tabs[2]?.getAttribute("aria-selected")).toBe("false");
+  });
+
+  test("Tabs without label interaction", () => {
+    const onTabClick = [jest.fn(), jest.fn(), jest.fn()];
+    const { getAllByRole } = render(sampleTabsWithoutLabel(onTabClick));
+    const tabs = getAllByRole("tab");
+    tabs[0] && fireEvent.click(tabs[0]);
+    expect(onTabClick[0]).toHaveBeenCalled();
+    expect(tabs[0]?.getAttribute("aria-selected")).toBe("true");
+    expect(tabs[1]?.getAttribute("aria-selected")).toBe("false");
+    expect(tabs[2]?.getAttribute("aria-selected")).toBe("false");
+    tabs[1] && fireEvent.click(tabs[1]);
+    expect(onTabClick[1]).toHaveBeenCalled();
+    expect(tabs[0]?.getAttribute("aria-selected")).toBe("false");
+    expect(tabs[1]?.getAttribute("aria-selected")).toBe("true");
+    expect(tabs[2]?.getAttribute("aria-selected")).toBe("false");
+    tabs[2] && fireEvent.click(tabs[2]);
+    expect(onTabClick[2]).toHaveBeenCalled();
+    expect(tabs[0]?.getAttribute("aria-selected")).toBe("false");
+    expect(tabs[1]?.getAttribute("aria-selected")).toBe("false");
+    expect(tabs[2]?.getAttribute("aria-selected")).toBe("true");
   });
 });

--- a/packages/lib/src/tabs/Tabs.tsx
+++ b/packages/lib/src/tabs/Tabs.tsx
@@ -116,7 +116,7 @@ const DxcTabs = ({
         )
       : childrenArray.find((child) => isValidElement(child) && !child.props.disabled);
 
-    return isValidElement(initialActiveTab) ? initialActiveTab.props.tabId : "";
+    return isValidElement(initialActiveTab) ? (initialActiveTab.props.label ?? initialActiveTab.props.tabId) : "";
   });
   const [countClick, setCountClick] = useState(0);
   const [innerFocusIndex, setInnerFocusIndex] = useState<number | null>(null);
@@ -131,7 +131,7 @@ const DxcTabs = ({
     const focusedChild = innerFocusIndex != null ? childrenArray[innerFocusIndex] : null;
     return {
       activeTabId: activeTabId,
-      focusedTabId: isValidElement(focusedChild) ? focusedChild.props.tabId : "",
+      focusedTabId: isValidElement(focusedChild) ? (focusedChild.props.label ?? focusedChild.props.tabId) : "",
       iconPosition,
       isControlled: childrenArray.some((child) => isValidElement(child) && typeof child.props.active !== "undefined"),
       setActiveTabId: setActiveTabId,
@@ -172,7 +172,9 @@ const DxcTabs = ({
   };
 
   const handleOnKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    const activeTab = childrenArray.findIndex((child: ReactElement) => child.props.tabId === activeTabId);
+    const activeTab = childrenArray.findIndex(
+      (child: ReactElement) => (child.props.label ?? child.props.tabId) === activeTabId
+    );
     switch (event.key) {
       case "Left":
       case "ArrowLeft":

--- a/packages/lib/src/tabs/types.ts
+++ b/packages/lib/src/tabs/types.ts
@@ -18,8 +18,8 @@ type TabCommonProps = {
 };
 
 export type TabsContextProps = {
-  activeTabId: string;
-  focusedTabId: string;
+  activeTabId?: string;
+  focusedTabId?: string;
   iconPosition?: "top" | "left";
   isControlled: boolean;
   setActiveTabId: (_tab: string) => void;
@@ -63,7 +63,7 @@ export type TabProps = {
   defaultActive?: boolean;
   active?: boolean;
   title?: string;
-  tabId: string;
+  tabId?: string;
   disabled?: boolean;
   notificationNumber?: boolean | number;
   children: ReactNode;

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "@dxc-technology/typescript-config/react-library.json",
+  "extends": "../typescript-config/react-library.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "outDir": "dist",
     "forceConsistentCasingInFileNames": true
   },

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../typescript-config/react-library.json",
+  "extends": "@dxc-technology/typescript-config/react-library.json",
   "compilerOptions": {
     "jsx": "react-jsx",
     "outDir": "dist",


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
To avoid creating a breaking change for now we will default the `tabId` value to the label if this one is set.