### PR TITLE
Added virtualization to Paginator Select

### DIFF
--- a/apps/website/screens/components/paginator/code/PaginatorCodePage.tsx
+++ b/apps/website/screens/components/paginator/code/PaginatorCodePage.tsx
@@ -46,7 +46,8 @@ const sections = [
             </td>
             <td>
               An array of numbers representing the items per page options. If undefined, the select with items per page
-              options will not be displayed.
+              options will not be displayed. If there are 100 or more options, the select will be virtualized for better
+              performance.
             </td>
             <td>-</td>
           </tr>

--- a/packages/lib/src/number-input/NumberInput.stories.tsx
+++ b/packages/lib/src/number-input/NumberInput.stories.tsx
@@ -3,11 +3,59 @@ import ExampleContainer from "../../.storybook/components/ExampleContainer";
 import Title from "../../.storybook/components/Title";
 import DxcFlex from "../flex/Flex";
 import DxcNumberInput from "./NumberInput";
+import { useState } from "react";
+import DxcTextInput from "../text-input/TextInput";
 
 export default {
   title: "Number Input",
   component: DxcNumberInput,
 } as Meta<typeof DxcNumberInput>;
+
+// const formatNumber = (value: string | number, decimals = 2, thousandSep = ",", decimalSep = ".") => {
+//   if (value === "" || isNaN(Number(value))) return "";
+//   const fixed = Number(value).toFixed(decimals);
+//   const [intPart, decPart] = fixed.split(thousandSep);
+//   const withThousands = intPart?.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSep) ?? "";
+//   return decPart ? `${withThousands}${decimalSep}${decPart}` : withThousands;
+// };
+
+// const NumberInputWithFormat = () => {
+//   const [value, setValue] = useState("");
+
+//   const handleUpdate = ({ value }) => {
+//     setValue(value);
+//     const numericValue = formatNumber(value);
+//     console.log("NUMERICVALUE", numericValue);
+//   };
+
+//   return <DxcNumberInput label="Importe" value={value} onChange={handleUpdate} onBlur={handleUpdate} />;
+// };
+
+const formatNumber = (value: string, locale: string = "es-ES", decimals: number = 2) => {
+  if (value === "" || isNaN(Number(value))) return value;
+  const number = Number(value);
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  }).format(number);
+};
+
+const NumberInputWithFormat = () => {
+  const [value, setValue] = useState("");
+
+  const handleChange = ({ value }: { value: string }) => {
+    // Prevent other characters than numbers, comma, dot and minus
+    const filtered = value.replace(/[^0-9.,-]/g, "");
+    setValue(filtered);
+  };
+
+  const handleBlur = ({ value }: { value: string }) => {
+    const formatted = formatNumber(value, "en-EN", 2);
+    setValue(formatted);
+  };
+
+  return <DxcTextInput pattern="^[0-9.,-]*$" value={value} onChange={handleChange} onBlur={handleBlur} prefix="$" />;
+};
 
 const NumberInput = () => (
   <>
@@ -125,6 +173,10 @@ const NumberInput = () => (
         <DxcNumberInput label="medium" size="medium" />
         <DxcNumberInput label="large" size="large" />
       </DxcFlex>
+    </ExampleContainer>
+    <ExampleContainer>
+      <Title title="Amount" theme="light" level={4} />
+      <NumberInputWithFormat />
     </ExampleContainer>
   </>
 );

--- a/packages/lib/src/number-input/NumberInput.stories.tsx
+++ b/packages/lib/src/number-input/NumberInput.stories.tsx
@@ -3,59 +3,11 @@ import ExampleContainer from "../../.storybook/components/ExampleContainer";
 import Title from "../../.storybook/components/Title";
 import DxcFlex from "../flex/Flex";
 import DxcNumberInput from "./NumberInput";
-import { useState } from "react";
-import DxcTextInput from "../text-input/TextInput";
 
 export default {
   title: "Number Input",
   component: DxcNumberInput,
 } as Meta<typeof DxcNumberInput>;
-
-// const formatNumber = (value: string | number, decimals = 2, thousandSep = ",", decimalSep = ".") => {
-//   if (value === "" || isNaN(Number(value))) return "";
-//   const fixed = Number(value).toFixed(decimals);
-//   const [intPart, decPart] = fixed.split(thousandSep);
-//   const withThousands = intPart?.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSep) ?? "";
-//   return decPart ? `${withThousands}${decimalSep}${decPart}` : withThousands;
-// };
-
-// const NumberInputWithFormat = () => {
-//   const [value, setValue] = useState("");
-
-//   const handleUpdate = ({ value }) => {
-//     setValue(value);
-//     const numericValue = formatNumber(value);
-//     console.log("NUMERICVALUE", numericValue);
-//   };
-
-//   return <DxcNumberInput label="Importe" value={value} onChange={handleUpdate} onBlur={handleUpdate} />;
-// };
-
-const formatNumber = (value: string, locale: string = "es-ES", decimals: number = 2) => {
-  if (value === "" || isNaN(Number(value))) return value;
-  const number = Number(value);
-  return new Intl.NumberFormat(locale, {
-    minimumFractionDigits: decimals,
-    maximumFractionDigits: decimals,
-  }).format(number);
-};
-
-const NumberInputWithFormat = () => {
-  const [value, setValue] = useState("");
-
-  const handleChange = ({ value }: { value: string }) => {
-    // Prevent other characters than numbers, comma, dot and minus
-    const filtered = value.replace(/[^0-9.,-]/g, "");
-    setValue(filtered);
-  };
-
-  const handleBlur = ({ value }: { value: string }) => {
-    const formatted = formatNumber(value, "en-EN", 2);
-    setValue(formatted);
-  };
-
-  return <DxcTextInput pattern="^[0-9.,-]*$" value={value} onChange={handleChange} onBlur={handleBlur} prefix="$" />;
-};
 
 const NumberInput = () => (
   <>
@@ -173,10 +125,6 @@ const NumberInput = () => (
         <DxcNumberInput label="medium" size="medium" />
         <DxcNumberInput label="large" size="large" />
       </DxcFlex>
-    </ExampleContainer>
-    <ExampleContainer>
-      <Title title="Amount" theme="light" level={4} />
-      <NumberInputWithFormat />
     </ExampleContainer>
   </>
 );

--- a/packages/lib/src/paginator/Paginator.stories.tsx
+++ b/packages/lib/src/paginator/Paginator.stories.tsx
@@ -29,6 +29,10 @@ const Paginator = () => (
       <DxcPaginator itemsPerPageOptions={[5, 10, 15]} />
     </ExampleContainer>
     <ExampleContainer>
+      <Title title="Default with items per page options virtualized" theme="light" level={4} />
+      <DxcPaginator itemsPerPageOptions={Array.from({ length: 10000 }, (_, i) => i + 1)} />
+    </ExampleContainer>
+    <ExampleContainer>
       <Title title="Default with show go to page selector" theme="light" level={4} />
       <DxcPaginator showGoToPage />
     </ExampleContainer>

--- a/packages/lib/src/paginator/Paginator.stories.tsx
+++ b/packages/lib/src/paginator/Paginator.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import ExampleContainer from "../../.storybook/components/ExampleContainer";
 import Title from "../../.storybook/components/Title";
 import DxcPaginator from "./Paginator";
+import { userEvent, within } from "@storybook/test";
 
 export default {
   title: "Paginator",
@@ -80,6 +81,13 @@ type Story = StoryObj<typeof DxcPaginator>;
 
 export const Chromatic: Story = {
   render: Paginator,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const virtualizedSelect = canvas.getAllByRole("combobox")[1];
+    if (virtualizedSelect) {
+      await userEvent.click(virtualizedSelect);
+    }
+  },
 };
 
 export const ResponsivePaginator: Story = {

--- a/packages/lib/src/paginator/Paginator.stories.tsx
+++ b/packages/lib/src/paginator/Paginator.stories.tsx
@@ -96,4 +96,11 @@ export const ResponsivePaginator: Story = {
     viewport: { viewports: customViewports, defaultViewport: "resizedScreen" },
     chromatic: { viewports: [400] },
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const virtualizedSelect = canvas.getAllByRole("combobox")[1];
+    if (virtualizedSelect) {
+      await userEvent.click(virtualizedSelect);
+    }
+  },
 };

--- a/packages/lib/src/paginator/Paginator.tsx
+++ b/packages/lib/src/paginator/Paginator.tsx
@@ -102,6 +102,7 @@ const DxcPaginator = ({
               value={itemsPerPage.toString()}
               size="fillParent"
               tabIndex={tabIndex}
+              virtualizedHeight={itemsPerPageOptions.length >= 100 ? "304px" : undefined}
             />
           </SelectContainer>
         </ItemsPerPageContainer>


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [ ] Build process is done without errors. All tests pass in the `/lib` directory.
- [ ] Self-reviewed the code before submitting.
- [ ] Meets accessibility standards.
- [ ] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Description**
We already support virtualization for `Select` but `Paginator` was not making use of it. I have defined a threshold in which arrays with size higher than 100, where the performance starts to become worse, it is appropiate to incorporate it, using a `virtualHeight` of 304px which is the `max-height` that we previously supported on the Select.

**Closes**
[OC-19102](https://jira.dxc.com/browse/OC-19102)