### PR TITLE
Reimplement radio group to use primary color token

### DIFF
--- a/packages/lib/src/radio-group/utils.tsx
+++ b/packages/lib/src/radio-group/utils.tsx
@@ -21,10 +21,10 @@ export function getRadioInputStyles(
           : "var(--color-fg-neutral-stronger)";
     default:
       return status === "default"
-        ? "var(--color-fg-secondary-medium)"
+        ? "var(--color-fg-primary-strong)"
         : status === "hover"
-          ? "var(--color-fg-secondary-strong)"
-          : "var(--color-fg-secondary-stronger)";
+          ? "var(--color-fg-primary-stronger)"
+          : "var(--color-fg-primary-stronger)";
   }
 }
 


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
The component was using “secondary color” token instead of the primary one, being inconsistent with the rest of the components.