### PR TITLE
[minor] Added inline styles for HalstackProvider

### DIFF
--- a/apps/website/screens/utilities/halstack-provider/HalstackProviderPage.tsx
+++ b/apps/website/screens/utilities/halstack-provider/HalstackProviderPage.tsx
@@ -53,6 +53,19 @@ const sections = [
             <td>Object with a given structure, specified below, for defining the opinionated theme.</td>
             <td>-</td>
           </tr>
+          <tr>
+            <td>
+              <DxcFlex direction="column" gap="var(--spacing-gap-xs)" alignItems="baseline">
+                <StatusBadge status="new" />
+                style
+              </DxcFlex>
+            </td>
+            <td>
+              <TableCode>React.CSSProperties</TableCode>
+            </td>
+            <td>CSS properties for styling the provider.</td>
+            <td>-</td>
+          </tr>
         </tbody>
       </DxcTable>
     ),

--- a/packages/lib/src/HalstackContext.tsx
+++ b/packages/lib/src/HalstackContext.tsx
@@ -35,6 +35,7 @@ type HalstackProviderPropsType = {
   labels?: DeepPartial<TranslatedLabels>;
   children: ReactNode;
   opinionatedTheme?: ThemeType;
+  style?: React.CSSProperties;
 };
 
 const HalstackThemed = styled.div<{ coreTheme?: ThemeType }>`
@@ -63,7 +64,7 @@ const createCoreTheme = (opinionatedTheme: ThemeType | undefined = {}) => {
   return newTheme;
 };
 
-const HalstackProvider = ({ labels, children, opinionatedTheme }: HalstackProviderPropsType): JSX.Element => {
+const HalstackProvider = ({ labels, children, opinionatedTheme, style }: HalstackProviderPropsType): JSX.Element => {
   const parsedLabels = useMemo(() => (labels ? parseLabels(labels) : null), [labels]);
   const parsedCoreTheme = useMemo(() => {
     const theme = createCoreTheme(opinionatedTheme);
@@ -71,7 +72,7 @@ const HalstackProvider = ({ labels, children, opinionatedTheme }: HalstackProvid
   }, [opinionatedTheme]);
 
   return (
-    <HalstackThemed coreTheme={parsedCoreTheme}>
+    <HalstackThemed coreTheme={parsedCoreTheme} style={style}>
       {parsedLabels ? (
         <HalstackLanguageContext.Provider value={parsedLabels}>{children}</HalstackLanguageContext.Provider>
       ) : (


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [ ] Build process is done without errors. All tests pass in the `/lib` directory.
- [ ] Self-reviewed the code before submitting.
- [ ] Meets accessibility standards.
- [ ] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Description**
When developing the new Theme Generator tool, we found some limitations regarding styles in the `HalstackProvider` component, so we decided that the best approach was to add the possibility to include inline styles on it.