### PR TITLE
Fix card content wrapping and sizing

### DIFF
--- a/packages/lib/src/card/Card.tsx
+++ b/packages/lib/src/card/Card.tsx
@@ -69,13 +69,13 @@ const ImageContainer = styled.div<{ imageBgColor: CardPropsType["imageBgColor"] 
 `;
 
 const CardContent = styled.div`
+  flex: 1 1 auto;
+  min-width: 0;
   align-items: flex-start;
   align-self: stretch;
   display: flex;
   flex-direction: column;
-  flex-shrink: 0;
   gap: var(--spacing-gap-ml);
-  overflow: hidden;
   padding: var(--spacing-padding-l);
 `;
 


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [ ] Added/updated documentation to `/website` as needed.
- [ ] Added/updated tests as needed.

**Purpose**
Fix card layout so text wraps correctly and the card grows with content instead of overflowing.

**Description**
Ensure content area grows and wraps properly with flex: 1 1 0 and min-width: 0.

**Screenshots**
<img width="902" height="422" alt="Screenshot from 2026-04-23 20-46-16" src="https://github.com/user-attachments/assets/1da1c88d-f0ce-45b4-8580-6bcd7bc8286a" />


**Additional context**
N/A

**Closes #2463**
