### PR TITLE
[patch] Correct Structure applied with error message and do not allow the pic…

### DIFF
--- a/packages/lib/src/time-input/TimeInput.tsx
+++ b/packages/lib/src/time-input/TimeInput.tsx
@@ -406,13 +406,13 @@ const DxcTimeInput = forwardRef<RefType, TimeInputPropsType>(
                   disabled={disabled}
                   icon="schedule"
                   title={!disabled ? translatedLabels.timeInput.timePickerActionTitle : undefined}
-                  onClick={() => setIsOpen(true)}
+                  onClick={() => !readOnly && setIsOpen(true)}
                 />
               </DxcPopover>
             </DxcFlex>
           </TimeInputField>
+          {!disabled && typeof error === "string" && <ErrorMessage error={error} id={errorId} />}
         </TimeInputContainer>
-        {!disabled && typeof error === "string" && <ErrorMessage error={error} id={errorId} />}
         <input
           aria-label={label ?? ariaLabel}
           aria-errormessage={error ? errorId : undefined}


### PR DESCRIPTION
…ker to open when readOnly

**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

Corect position for the error message and correctly disable the picker if readOnly is true
