### PR TITLE
[patch] Default calendar without locale behavior

### DIFF
--- a/packages/lib/src/date-input/Calendar.tsx
+++ b/packages/lib/src/date-input/Calendar.tsx
@@ -104,8 +104,8 @@ const Calendar = ({
   const id = useId();
   const languageContext = useContext(HalstackLanguageContext);
   const translatedLabels = languageContext?.labels;
-  const localeTag = languageContext?.locale || navigator.language;
-  const locale = new Intl.Locale(validateLocale(localeTag) ? localeTag : "en");
+  const localeTag = languageContext?.locale || undefined;
+  const locale = localeTag ? new Intl.Locale(validateLocale(localeTag) ? localeTag : "en") : undefined;
   const firstDayOfWeek = (locale ? (locale.getWeekInfo?.()?.firstDay ?? 1) : 1) % 7;
   const dayCells = useMemo(() => getCalendarDays(innerDate, firstDayOfWeek), [innerDate, firstDayOfWeek]);
 


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
The default behavior was reverted in case a locale was not provided
