### PR TITLE
[patch] NavItems in header correctly triggers when collapsed and inside a tooltip

### DIFF
--- a/packages/lib/src/base-menu/ItemAction.tsx
+++ b/packages/lib/src/base-menu/ItemAction.tsx
@@ -91,7 +91,7 @@ const ItemAction = memo(
       handleTextMouseEnter,
       getWrapper,
     } = useItemAction(props);
-    const { depthLevel, selected, href, label, icon, collapseIcon, ...rest } = props;
+    const { depthLevel, selected, href, label, icon, collapseIcon, onClick, ...rest } = props;
     const ariaPressed = !href ? !!selected : undefined;
     const ariaSelected = href ? !!selected : undefined;
     return getWrapper(
@@ -106,6 +106,7 @@ const ItemAction = memo(
           hasPopOver={hasPopOver}
           isHorizontal={isHorizontal}
           {...(href && { href })}
+          onClick={onClick}
           {...rest}
           aria-pressed={ariaPressed}
           aria-selected={ariaSelected}


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
This should avoid multiple triggers when any option iis a group and at the same time is collapsed.