### PR TITLE
[patch] Added stop propagation to onEscapeKeyDown in Popover

### DIFF
--- a/packages/lib/src/popover/Popover.tsx
+++ b/packages/lib/src/popover/Popover.tsx
@@ -110,7 +110,10 @@ const DxcPopover = ({
                 onCloseAutoFocus?.(event);
               }}
               onInteractOutside={() => handleTrigger(isControlled.current, setOpened, false, onClose)}
-              onEscapeKeyDown={() => handleTrigger(isControlled.current, setOpened, false, onClose)}
+              onEscapeKeyDown={(event: KeyboardEvent) => {
+                event.stopPropagation();
+                handleTrigger(isControlled.current, setOpened, false, onClose);
+              }}
               onMouseEnter={
                 actionToOpen === "hover"
                   ? () => handleTrigger(isControlled.current, setOpened, true, onOpen)


### PR DESCRIPTION
**Checklist**
_(Check off all the items before submitting)_

- [x] Build process is done without errors. All tests pass in the `/lib` directory.
- [x] Self-reviewed the code before submitting.
- [x] Meets accessibility standards.
- [x] Added/updated documentation to `/website` as needed.
- [x] Added/updated tests as needed.

**Purpose**
This should avoid unintended behavior when a popover is opened inside another element that uses the escape key.
